### PR TITLE
feat: leg history panel (#6) and best-of indicator + leg timer (#10)

### DIFF
--- a/src/lib/components/scoring/LegHistory.svelte
+++ b/src/lib/components/scoring/LegHistory.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	export interface LegRecord {
+		legNumber: number;
+		winnerName: string;
+		dartsThrown: number;
+		highestTurn: number;
+		checkoutScore: number;
+	}
+
+	interface Props {
+		legs: LegRecord[];
+		currentLegNumber: number;
+	}
+
+	let { legs, currentLegNumber }: Props = $props();
+
+	let expanded = $state(true);
+
+	function checkoutLabel(score: number): string {
+		if (score === 50) return 'Bull';
+		if (score === 25) return 'SBull';
+		// Simple approximation — show the raw checkout value
+		return `${score}`;
+	}
+</script>
+
+<div class="card bg-base-100 shadow-sm" data-testid="leg-history">
+	<div class="card-body p-3">
+		<button
+			class="flex items-center justify-between w-full text-left"
+			onclick={() => (expanded = !expanded)}
+			aria-expanded={expanded}
+		>
+			<h3 class="font-semibold text-sm">Leg-Verlauf</h3>
+			<svg
+				class="w-4 h-4 transition-transform duration-200 {expanded ? 'rotate-180' : ''}"
+				fill="none" stroke="currentColor" stroke-width="2"
+				viewBox="0 0 24 24"
+			>
+				<path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+			</svg>
+		</button>
+
+		{#if expanded}
+			<div class="mt-2 flex flex-col gap-1" data-testid="leg-history-list">
+				{#if legs.length === 0}
+					<!-- Dummy placeholder row when no legs finished yet -->
+					<div class="flex items-center gap-2 text-xs text-base-content/30 italic px-1">
+						<span class="w-10">Leg 1</span>
+						<span>— noch keine Legs beendet —</span>
+					</div>
+				{:else}
+					{#each legs as leg (leg.legNumber)}
+						<div class="flex items-center gap-2 text-xs px-1 py-0.5 rounded bg-base-200" data-testid="leg-history-row">
+							<span class="w-10 text-base-content/60 shrink-0">Leg {leg.legNumber}</span>
+							<span class="font-semibold flex items-center gap-1 flex-1 truncate">
+								<span>✓</span>
+								<span class="truncate">{leg.winnerName}</span>
+							</span>
+							<span class="text-base-content/60 shrink-0">⬤ {leg.dartsThrown}</span>
+							<span class="text-base-content/60 shrink-0">★ {leg.highestTurn}</span>
+							<span class="text-base-content/60 shrink-0">⊗ {checkoutLabel(leg.checkoutScore)}</span>
+						</div>
+					{/each}
+				{/if}
+
+				<!-- Current leg in-progress row -->
+				<div class="flex items-center gap-2 text-xs px-1 py-0.5 rounded border border-dashed border-base-300" data-testid="leg-history-current">
+					<span class="w-10 text-base-content/60 shrink-0">Leg {currentLegNumber}</span>
+					<span class="text-base-content/40 italic">— läuft —</span>
+				</div>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/src/lib/components/scoring/ScoreBoard.svelte
+++ b/src/lib/components/scoring/ScoreBoard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import type { GameStore } from '$lib/stores/game.svelte.js';
 
 	interface Props {
@@ -9,6 +10,82 @@
 
 	const homeActive = $derived(game.current_player_id === game.home_player.id);
 	const awayActive = $derived(game.current_player_id === game.away_player.id);
+
+	// --- Elapsed leg timer ---
+	const TIMER_STORAGE_KEY = 'dartzone_timer_enabled';
+
+	let timerEnabled = $state(
+		browser ? (localStorage.getItem(TIMER_STORAGE_KEY) ?? 'true') !== 'false' : true
+	);
+	let elapsedSeconds = $state(0);
+	let timerStarted = $state(false);
+	let intervalId = $state<ReturnType<typeof setInterval> | null>(null);
+
+	function formatTime(secs: number): string {
+		const m = Math.floor(secs / 60).toString().padStart(2, '0');
+		const s = (secs % 60).toString().padStart(2, '0');
+		return `${m}:${s}`;
+	}
+
+	function startTimer() {
+		if (intervalId) return;
+		intervalId = setInterval(() => {
+			if (!document.hidden) elapsedSeconds++;
+		}, 1000);
+	}
+
+	function stopTimer() {
+		if (intervalId) {
+			clearInterval(intervalId);
+			intervalId = null;
+		}
+	}
+
+	// Start timer on first throw of this leg
+	$effect(() => {
+		if (!browser || !timerEnabled) return;
+		if (game.throws.length > 0 && !timerStarted) {
+			timerStarted = true;
+			startTimer();
+		}
+	});
+
+	// Stop timer when leg completes
+	$effect(() => {
+		if (game.status === 'completed') {
+			stopTimer();
+		}
+	});
+
+	// Reset when leg_number changes (new game object passed in)
+	$effect(() => {
+		// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+		game.leg_number; // reactive dependency
+		elapsedSeconds = 0;
+		timerStarted = false;
+		stopTimer();
+	});
+
+	// Page Visibility API — pause timer when tab is hidden
+	$effect(() => {
+		if (!browser) return;
+		function handleVisibility() {
+			if (document.hidden) {
+				stopTimer();
+			} else if (timerStarted && game.status !== 'completed') {
+				startTimer();
+			}
+		}
+		document.addEventListener('visibilitychange', handleVisibility);
+		return () => document.removeEventListener('visibilitychange', handleVisibility);
+	});
+
+	function toggleTimer() {
+		timerEnabled = !timerEnabled;
+		if (browser) localStorage.setItem(TIMER_STORAGE_KEY, timerEnabled ? 'true' : 'false');
+		if (!timerEnabled) stopTimer();
+		else if (timerStarted && game.status !== 'completed') startTimer();
+	}
 </script>
 
 <div class="grid grid-cols-3 gap-2" data-testid="scoreboard">
@@ -27,12 +104,39 @@
 		</div>
 	</div>
 
-	<div class="flex flex-col items-center justify-center">
+	<div class="flex flex-col items-center justify-center gap-1">
 		<div class="text-sm text-base-content/60">Leg {game.leg_number}</div>
-		<div class="text-xs text-base-content/40 mt-1">Runde {game.current_turn}</div>
-		{#if game.status === 'completed'}
-			<div class="badge badge-success mt-2 animate-pulse" data-testid="scoreboard-completed">Checkout!</div>
+
+		{#if timerEnabled}
+			<div class="text-xs font-mono text-base-content/50 tabular-nums" data-testid="scoreboard-timer">
+				{formatTime(elapsedSeconds)}
+			</div>
 		{/if}
+
+		<div class="text-xs text-base-content/40">Runde {game.current_turn}</div>
+
+		{#if game.status === 'completed'}
+			<div class="badge badge-success mt-1 animate-pulse" data-testid="scoreboard-completed">Checkout!</div>
+		{/if}
+
+		<button
+			class="btn btn-ghost btn-xs mt-1 opacity-40 hover:opacity-100"
+			onclick={toggleTimer}
+			title={timerEnabled ? 'Timer ausblenden' : 'Timer einblenden'}
+			data-testid="scoreboard-timer-toggle"
+		>
+			{#if timerEnabled}
+				<!-- Clock icon -->
+				<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+					<circle cx="12" cy="12" r="10" /><path stroke-linecap="round" d="M12 6v6l4 2" />
+				</svg>
+			{:else}
+				<!-- Clock-off icon -->
+				<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+					<path stroke-linecap="round" d="M3 3l18 18M12 6v3m0 0a9 9 0 017.74 13.5M4.26 6.5A9 9 0 0012 21a9 9 0 005.74-2.06" />
+				</svg>
+			{/if}
+		</button>
 	</div>
 
 	<div

--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
@@ -4,13 +4,15 @@
 	import ThrowHistory from '$lib/components/scoring/ThrowHistory.svelte';
 	import TurnIndicator from '$lib/components/scoring/TurnIndicator.svelte';
 	import CheckoutHelper from '$lib/components/scoring/CheckoutHelper.svelte';
+	import LegHistory from '$lib/components/scoring/LegHistory.svelte';
+	import type { LegRecord } from '$lib/components/scoring/LegHistory.svelte';
 	import AnimationOverlay from '$lib/components/animations/AnimationOverlay.svelte';
 	import ClubCrest from '$lib/components/clubs/ClubCrest.svelte';
 	import PlayerStatsCard from '$lib/components/scoring/PlayerStatsCard.svelte';
 	import type { PlayerStats } from '$lib/components/scoring/PlayerStatsCard.svelte';
 	import { createGameState, type GameStore } from '$lib/stores/game.svelte.js';
 	import { createAnimationStore } from '$lib/stores/animation.svelte.js';
-	import type { Multiplier, SectorValue } from '$lib/types/game.js';
+	import type { DartThrow, Multiplier, SectorValue } from '$lib/types/game.js';
 	import type { Player } from '$lib/types/club.js';
 
 	let { data } = $props();
@@ -26,6 +28,61 @@
 
 	let game = $state<GameStore | null>(null);
 	const animations = createAnimationStore();
+
+	// Leg history tracking
+	let completedLegs = $state<LegRecord[]>([]);
+
+	function extractLegRecord(g: GameStore): LegRecord {
+		const throws = g.throws;
+		const winnerId = g.winner_player_id!;
+		const winner = winnerId === g.home_player.id ? g.home_player : g.away_player;
+
+		// Darts thrown by the winner
+		const winnerThrows = throws.filter((t) => t.player_id === winnerId && !t.is_bust);
+		const dartsThrown = throws.filter((t) => t.player_id === winnerId).length;
+
+		// Highest turn score (sum of non-bust throws in a single turn for the winner)
+		const turnMap = new Map<number, number>();
+		for (const t of winnerThrows) {
+			turnMap.set(t.turn_number, (turnMap.get(t.turn_number) ?? 0) + t.score);
+		}
+		const highestTurn = turnMap.size > 0 ? Math.max(...turnMap.values()) : 0;
+
+		// Checkout score: score of the final throw
+		const lastThrow = [...throws].reverse().find((t) => t.player_id === winnerId && !t.is_bust);
+		const checkoutScore = lastThrow?.score ?? 0;
+
+		return {
+			legNumber: g.leg_number,
+			winnerName: `${winner.first_name} ${winner.last_name}`,
+			dartsThrown,
+			highestTurn,
+			checkoutScore
+		};
+	}
+
+	// Best-of / match progress derived values
+	const legsToWin = $derived(Math.ceil(data.tournament.sets_per_match / 2));
+	const totalLegs = $derived(data.tournament.sets_per_match);
+
+	const bestOfText = $derived(`Best of ${totalLegs} Legs`);
+
+	const progressText = $derived.by(() => {
+		const homeNeeds = legsToWin - homeLegsWon;
+		const awayNeeds = legsToWin - awayLegsWon;
+
+		if (homeLegsWon === awayLegsWon) return 'Gleichstand';
+		if (homeLegsWon > awayLegsWon) {
+			if (homeNeeds === 1) return `${data.match.home_club.short_name}: Match Point!`;
+			return `${data.match.home_club.short_name} führt — noch ${homeNeeds} Leg${homeNeeds !== 1 ? 's' : ''} zum Sieg`;
+		}
+		if (awayNeeds === 1) return `${data.match.away_club.short_name}: Match Point!`;
+		return `${data.match.away_club.short_name} führt — noch ${awayNeeds} Leg${awayNeeds !== 1 ? 's' : ''} zum Sieg`;
+	});
+
+	const isMatchPoint = $derived(
+		(legsToWin - homeLegsWon === 1) || (legsToWin - awayLegsWon === 1)
+	);
 
 	// Player stats for the selection screen
 	let homeStats = $state<PlayerStats | null>(null);
@@ -123,6 +180,9 @@
 		legSaving = true;
 		const winnerSide = game.winner_player_id === game.home_player.id ? 'home' : 'away';
 
+		// Capture leg record before resetting game state
+		const legRecord = extractLegRecord(game);
+
 		try {
 			const formData = new FormData();
 			formData.set('winner_side', winnerSide);
@@ -138,6 +198,8 @@
 				return;
 			}
 
+			completedLegs = [...completedLegs, legRecord];
+
 			if (winnerSide === 'home') {
 				homeLegsWon++;
 			} else {
@@ -145,7 +207,6 @@
 			}
 
 			// Check for match completion
-			const legsToWin = Math.ceil(data.tournament.sets_per_match / 2);
 			if (homeLegsWon >= legsToWin || awayLegsWon >= legsToWin) {
 				matchCompleted = true;
 				return;
@@ -178,32 +239,48 @@
 	</div>
 
 	<!-- Match Score Header -->
-	<div class="flex items-center justify-center gap-6 p-4 bg-base-100 rounded-lg shadow-sm" data-testid="match-score-header">
-		<div class="flex items-center gap-2">
-			<ClubCrest
-				club_id={data.match.home_club.id}
-				has_crest={data.match.home_club.has_crest}
-				crest_url={data.match.home_club.crest_url}
-				club_name={data.match.home_club.name}
-				primary_color={data.match.home_club.primary_color}
-				size={40}
-			/>
-			<span class="font-bold">{data.match.home_club.short_name}</span>
+	<div class="flex flex-col items-center gap-1 p-4 bg-base-100 rounded-lg shadow-sm" data-testid="match-score-header">
+		<div class="flex items-center justify-center gap-6 w-full">
+			<div class="flex items-center gap-2">
+				<ClubCrest
+					club_id={data.match.home_club.id}
+					has_crest={data.match.home_club.has_crest}
+					crest_url={data.match.home_club.crest_url}
+					club_name={data.match.home_club.name}
+					primary_color={data.match.home_club.primary_color}
+					size={40}
+				/>
+				<span class="font-bold">{data.match.home_club.short_name}</span>
+			</div>
+			<div class="text-3xl font-bold tabular-nums" data-testid="match-legs-score">
+				{homeLegsWon} : {awayLegsWon}
+			</div>
+			<div class="flex items-center gap-2">
+				<span class="font-bold">{data.match.away_club.short_name}</span>
+				<ClubCrest
+					club_id={data.match.away_club.id}
+					has_crest={data.match.away_club.has_crest}
+					crest_url={data.match.away_club.crest_url}
+					club_name={data.match.away_club.name}
+					primary_color={data.match.away_club.primary_color}
+					size={40}
+				/>
+			</div>
 		</div>
-		<div class="text-3xl font-bold tabular-nums" data-testid="match-legs-score">
-			{homeLegsWon} : {awayLegsWon}
-		</div>
-		<div class="flex items-center gap-2">
-			<span class="font-bold">{data.match.away_club.short_name}</span>
-			<ClubCrest
-				club_id={data.match.away_club.id}
-				has_crest={data.match.away_club.has_crest}
-				crest_url={data.match.away_club.crest_url}
-				club_name={data.match.away_club.name}
-				primary_color={data.match.away_club.primary_color}
-				size={40}
-			/>
-		</div>
+
+		<!-- Best-of indicator -->
+		{#if matchStarted && !matchCompleted}
+			<div class="flex flex-col items-center gap-1 mt-1" data-testid="best-of-indicator">
+				<span class="text-xs text-base-content/50">{bestOfText}</span>
+				{#if isMatchPoint}
+					<span class="badge badge-warning animate-pulse font-semibold" data-testid="match-point-badge">
+						{progressText}
+					</span>
+				{:else}
+					<span class="text-xs text-base-content/60" data-testid="progress-text">{progressText}</span>
+				{/if}
+			</div>
+		{/if}
 	</div>
 
 	{#if matchCompleted}
@@ -213,6 +290,11 @@
 				<p class="text-lg">
 					{homeLegsWon > awayLegsWon ? data.match.home_club.name : data.match.away_club.name} gewinnt!
 				</p>
+				{#if completedLegs.length > 0}
+					<div class="mt-4">
+						<LegHistory legs={completedLegs} currentLegNumber={legNumber} />
+					</div>
+				{/if}
 				<a href="/tournaments/{data.tournament.id}" class="btn btn-primary mt-4">Zum Turnier</a>
 			</div>
 		</div>
@@ -284,6 +366,9 @@
 		<ScoreBoard {game} />
 
 		<TurnIndicator {game} />
+
+		<!-- Leg History -->
+		<LegHistory legs={completedLegs} currentLegNumber={legNumber} />
 
 		<div class="grid gap-4 lg:grid-cols-2">
 			<div class="flex flex-col items-center gap-4">


### PR DESCRIPTION
## Summary

- **#6 Leg-by-leg score history**: New `LegHistory` component shows all completed legs in a compact list (winner ✓, darts thrown ⬤, highest turn ★, checkout score ⊗). An "in progress" placeholder row marks the current leg. Panel is collapsible via chevron. Appears during active play and on the match-completed screen. Leg data is extracted client-side from the game state at the moment each leg is confirmed.

- **#10 Best-of indicator + elapsed timer**:
  - Best-of format text (`Best of N Legs`) shown below the match score header once the match starts
  - Reactive progress text updates after each confirmed leg (leading player, legs needed, tied)
  - Pulsing `badge-warning` shown when either player reaches Match Point
  - Elapsed leg timer (MM:SS) in the ScoreBoard center column: starts on first throw, pauses via Page Visibility API when tab is hidden, resets when a new leg starts, toggleable via a small clock icon (preference persisted to localStorage)

## Test plan
- [ ] Start a match — best-of text appears, progress shows "Gleichstand"
- [ ] Confirm a leg — leg appears in history panel, progress text updates
- [ ] Win enough legs to reach match point — pulsing "Match Point!" badge appears
- [ ] Throw first dart — leg timer starts counting up from 00:00
- [ ] Switch tabs — timer pauses; switch back — resumes
- [ ] Click clock icon — timer hides; refresh — preference remembered
- [ ] Leg history shows correct winner, dart count, highest turn, and checkout

Closes #6, Closes #10