### PR TITLE
feat: manual score input keypad as dartboard fallback (#4)

### DIFF
--- a/src/lib/components/scoring/ScoreKeypad.svelte
+++ b/src/lib/components/scoring/ScoreKeypad.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+	import type { Multiplier, SectorValue } from '$lib/types/game.js';
+	import { calcScore } from '$lib/utils/scoring.js';
+
+	interface Props {
+		disabled?: boolean;
+		onhit?: (event: { sector: SectorValue; multiplier: Multiplier; score: number }) => void;
+	}
+
+	let { disabled = false, onhit }: Props = $props();
+
+	let activeMultiplier = $state<Multiplier>(1);
+	let error = $state<string | null>(null);
+	let textInput = $state('');
+
+	const SECTOR_NUMBERS: number[] = [
+		20, 19, 18, 17, 16, 15,
+		14, 13, 12, 11, 10, 9,
+		8, 7, 6, 5, 4, 3, 2, 1
+	];
+
+	function emitHit(sector: SectorValue, multiplier: Multiplier) {
+		if (disabled) return;
+		error = null;
+
+		// Validate: no triple on bull
+		if (sector === 25 && multiplier === 3) {
+			error = 'Triple Bull gibt es nicht';
+			return;
+		}
+
+		const score = calcScore(sector, multiplier);
+		onhit?.({ sector, multiplier, score });
+		activeMultiplier = 1;
+	}
+
+	function handleNumberClick(num: number) {
+		emitHit(num as SectorValue, activeMultiplier);
+	}
+
+	function handleBullClick() {
+		if (activeMultiplier === 3) {
+			error = 'Triple Bull gibt es nicht';
+			return;
+		}
+		const mult = activeMultiplier === 1 ? 1 : 2;
+		emitHit(25, mult as Multiplier);
+	}
+
+	function handleMissClick() {
+		emitHit(0 as SectorValue, 0);
+	}
+
+	function setMultiplier(m: Multiplier) {
+		error = null;
+		activeMultiplier = m;
+	}
+
+	// --- Text input parsing ---
+	function parseNotation(input: string): { sector: SectorValue; multiplier: Multiplier } | null {
+		const s = input.trim().toUpperCase();
+		if (!s) return null;
+
+		// Miss
+		if (s === '0' || s === 'MISS' || s === 'M') {
+			return { sector: 0 as SectorValue, multiplier: 0 };
+		}
+
+		// Double Bull / Bullseye
+		if (s === 'DB' || s === 'DBULL' || s === '50' || s === 'BULLSEYE') {
+			return { sector: 25, multiplier: 2 };
+		}
+
+		// Single Bull
+		if (s === 'BULL' || s === 'SBULL' || s === '25') {
+			return { sector: 25, multiplier: 1 };
+		}
+
+		// Prefixed notation: T20, D16, S5
+		const match = s.match(/^([TDS])(\d{1,2})$/);
+		if (match) {
+			const prefix = match[1];
+			const num = parseInt(match[2], 10);
+			if (num < 1 || num > 20) return null;
+
+			const multiplier: Multiplier = prefix === 'T' ? 3 : prefix === 'D' ? 2 : 1;
+			return { sector: num as SectorValue, multiplier };
+		}
+
+		// Plain number: 1-20
+		const num = parseInt(s, 10);
+		if (!isNaN(num) && num >= 1 && num <= 20) {
+			return { sector: num as SectorValue, multiplier: 1 };
+		}
+
+		return null;
+	}
+
+	function handleTextSubmit() {
+		if (disabled) return;
+		const parsed = parseNotation(textInput);
+		if (!parsed) {
+			error = `Ungültige Eingabe: "${textInput}"`;
+			return;
+		}
+
+		// Validate triple bull
+		if (parsed.sector === 25 && parsed.multiplier === 3) {
+			error = 'Triple Bull gibt es nicht';
+			return;
+		}
+
+		emitHit(parsed.sector, parsed.multiplier);
+		textInput = '';
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') {
+			handleTextSubmit();
+		}
+	}
+
+	const multiplierLabel = $derived(
+		activeMultiplier === 3 ? 'Triple' : activeMultiplier === 2 ? 'Double' : 'Single'
+	);
+</script>
+
+<div class="flex flex-col gap-3" data-testid="score-keypad">
+	<!-- Text input -->
+	<div class="flex gap-2">
+		<input
+			type="text"
+			class="input input-bordered input-sm flex-1 font-mono"
+			placeholder="T20, D16, Bull, 0…"
+			bind:value={textInput}
+			onkeydown={handleKeydown}
+			{disabled}
+			data-testid="keypad-text-input"
+		/>
+		<button
+			class="btn btn-primary btn-sm"
+			onclick={handleTextSubmit}
+			{disabled}
+			data-testid="keypad-submit-btn"
+		>OK</button>
+	</div>
+
+	{#if error}
+		<div class="text-xs text-error" data-testid="keypad-error">{error}</div>
+	{/if}
+
+	<!-- Multiplier selector -->
+	<div class="flex gap-1" data-testid="keypad-multiplier">
+		<button
+			class="btn btn-sm flex-1 {activeMultiplier === 1 ? 'btn-primary' : 'btn-outline'}"
+			onclick={() => setMultiplier(1)}
+			{disabled}
+		>Single</button>
+		<button
+			class="btn btn-sm flex-1 {activeMultiplier === 2 ? 'btn-secondary' : 'btn-outline'}"
+			onclick={() => setMultiplier(2)}
+			{disabled}
+		>Double</button>
+		<button
+			class="btn btn-sm flex-1 {activeMultiplier === 3 ? 'btn-accent' : 'btn-outline'}"
+			onclick={() => setMultiplier(3)}
+			{disabled}
+		>Triple</button>
+	</div>
+
+	<!-- Number grid -->
+	<div class="grid grid-cols-5 gap-1" data-testid="keypad-numbers">
+		{#each SECTOR_NUMBERS as num}
+			<button
+				class="btn btn-sm tabular-nums {activeMultiplier === 3 ? 'btn-accent btn-outline' : activeMultiplier === 2 ? 'btn-secondary btn-outline' : 'btn-ghost'}"
+				onclick={() => handleNumberClick(num)}
+				{disabled}
+			>
+				{activeMultiplier === 3 ? 'T' : activeMultiplier === 2 ? 'D' : ''}{num}
+			</button>
+		{/each}
+	</div>
+
+	<!-- Bull and Miss row -->
+	<div class="flex gap-1">
+		<button
+			class="btn btn-sm flex-1 {activeMultiplier === 2 ? 'btn-warning' : 'btn-outline btn-warning'}"
+			onclick={handleBullClick}
+			{disabled}
+			data-testid="keypad-bull"
+		>
+			{activeMultiplier === 2 ? 'Bullseye (50)' : 'Bull (25)'}
+		</button>
+		<button
+			class="btn btn-sm flex-1 btn-ghost"
+			onclick={handleMissClick}
+			{disabled}
+			data-testid="keypad-miss"
+		>Miss (0)</button>
+	</div>
+
+	<div class="text-xs text-base-content/40 text-center">
+		Modus: {multiplierLabel} — oder Kurzform eingeben (T20, D16, Bull)
+	</div>
+</div>

--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import Dartboard from '$lib/components/dartboard/Dartboard.svelte';
 	import ScoreBoard from '$lib/components/scoring/ScoreBoard.svelte';
+	import ScoreKeypad from '$lib/components/scoring/ScoreKeypad.svelte';
 	import ThrowHistory from '$lib/components/scoring/ThrowHistory.svelte';
 	import TurnIndicator from '$lib/components/scoring/TurnIndicator.svelte';
 	import CheckoutHelper from '$lib/components/scoring/CheckoutHelper.svelte';
@@ -28,6 +30,20 @@
 
 	let game = $state<GameStore | null>(null);
 	const animations = createAnimationStore();
+
+	// Input mode: 'dartboard' | 'keypad' | 'both'
+	const INPUT_MODE_KEY = 'dartzone_input_mode';
+	type InputMode = 'dartboard' | 'keypad' | 'both';
+	let inputMode = $state<InputMode>(
+		(browser ? localStorage.getItem(INPUT_MODE_KEY) as InputMode : null) ?? 'dartboard'
+	);
+
+	function cycleInputMode() {
+		const modes: InputMode[] = ['dartboard', 'keypad', 'both'];
+		const idx = modes.indexOf(inputMode);
+		inputMode = modes[(idx + 1) % modes.length];
+		if (browser) localStorage.setItem(INPUT_MODE_KEY, inputMode);
+	}
 
 	// Leg history tracking
 	let completedLegs = $state<LegRecord[]>([]);
@@ -372,11 +388,55 @@
 
 		<div class="grid gap-4 lg:grid-cols-2">
 			<div class="flex flex-col items-center gap-4">
-				<Dartboard
-					size={350}
-					disabled={game.status === 'completed'}
-					onhit={handleHit}
-				/>
+				<!-- Input mode toggle -->
+				<div class="flex items-center gap-2">
+					<button
+						class="btn btn-ghost btn-xs"
+						onclick={cycleInputMode}
+						title="Eingabemodus wechseln"
+						data-testid="input-mode-toggle"
+					>
+						{#if inputMode === 'dartboard'}
+							<!-- Dartboard icon -->
+							<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+								<circle cx="12" cy="12" r="10" /><circle cx="12" cy="12" r="6" /><circle cx="12" cy="12" r="2" />
+							</svg>
+							<span class="text-xs">Dartboard</span>
+						{:else if inputMode === 'keypad'}
+							<!-- Keypad icon -->
+							<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+								<rect x="4" y="4" width="16" height="16" rx="2" /><path d="M8 8h.01M12 8h.01M16 8h.01M8 12h.01M12 12h.01M16 12h.01M8 16h.01M12 16h.01M16 16h.01" stroke-linecap="round" />
+							</svg>
+							<span class="text-xs">Tastatur</span>
+						{:else}
+							<!-- Both icon -->
+							<svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+								<circle cx="8" cy="12" r="5" /><rect x="14" y="8" width="8" height="8" rx="1" />
+							</svg>
+							<span class="text-xs">Beides</span>
+						{/if}
+					</button>
+				</div>
+
+				<!-- Dartboard (shown in dartboard or both mode) -->
+				{#if inputMode === 'dartboard' || inputMode === 'both'}
+					<Dartboard
+						size={inputMode === 'both' ? 280 : 350}
+						disabled={game.status === 'completed'}
+						onhit={handleHit}
+					/>
+				{/if}
+
+				<!-- Keypad (shown in keypad or both mode) -->
+				{#if inputMode === 'keypad' || inputMode === 'both'}
+					<div class="w-full max-w-xs">
+						<ScoreKeypad
+							disabled={game.status === 'completed'}
+							onhit={handleHit}
+						/>
+					</div>
+				{/if}
+
 				<div class="flex flex-wrap items-center gap-2">
 					<button
 						class="btn btn-outline btn-sm"


### PR DESCRIPTION
## Summary

- New `ScoreKeypad` component with three input methods:
  - **Text input** accepting shorthand notation: `T20`, `D16`, `S5`, `Bull`, `DB`/`50`, `0`/`Miss`
  - **Multiplier buttons** (Single/Double/Triple) + **number grid** (1–20) — button labels update to show prefix (e.g. T14, D7)
  - **Bull** (adapts to selected multiplier: Bull 25 or Bullseye 50) and **Miss** quick buttons
- Invalid inputs show inline error (e.g. "Triple Bull gibt es nicht" for T25)
- Three-way **input mode toggle** on the play page: Dartboard / Keypad / Both
  - In "both" mode, dartboard renders smaller (280px) alongside the keypad
  - Mode preference persisted to localStorage
- Keypad calls the same `handleHit()` path as dartboard clicks — all game logic, undo, and animations work identically

## Test plan
- [ ] Switch to keypad mode — number grid and text input visible, dartboard hidden
- [ ] Tap S/D/T prefix then a number — correct throw registered
- [ ] Type `T20` in text input + Enter — registers Triple 20 (60 pts)
- [ ] Type `Bull` — registers Single Bull (25 pts)
- [ ] Type `T25` — shows error "Triple Bull gibt es nicht"
- [ ] Switch to "both" mode — dartboard + keypad shown side by side
- [ ] Refresh page — input mode preference remembered
- [ ] Undo works correctly for keypad-entered throws

Closes #4