### PR TITLE
feat: mobile dartboard quadrant zoom mode (#5)

### DIFF
--- a/src/lib/components/dartboard/Dartboard.svelte
+++ b/src/lib/components/dartboard/Dartboard.svelte
@@ -20,16 +20,38 @@
 		id: string;
 	}
 
+	export type Quadrant = 'full' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
 	interface Props {
 		size?: number;
 		disabled?: boolean;
 		markers?: HitMarker[];
+		quadrant?: Quadrant;
 		onhit?: (event: HitEvent) => void;
 	}
 
-	let { size = 400, disabled = false, markers = [], onhit }: Props = $props();
+	let { size = 400, disabled = false, markers = [], quadrant = 'full', onhit }: Props = $props();
 
 	const boardRadius = $derived(size / 2);
+
+	// Quadrant viewBox: show a quarter of the board with overlap so the bull is always visible
+	const OVERLAP = 0.18;
+	const viewBox = $derived.by(() => {
+		const R = boardRadius;
+		const pad = R * OVERLAP;
+		switch (quadrant) {
+			case 'top-left':
+				return `${-R} ${-R} ${R + pad} ${R + pad}`;
+			case 'top-right':
+				return `${-pad} ${-R} ${R + pad} ${R + pad}`;
+			case 'bottom-left':
+				return `${-R} ${-pad} ${R + pad} ${R + pad}`;
+			case 'bottom-right':
+				return `${-pad} ${-pad} ${R + pad} ${R + pad}`;
+			default:
+				return `${-R} ${-R} ${size} ${size}`;
+		}
+	});
 
 	// Color scheme for the dartboard
 	const COLORS = {
@@ -115,7 +137,7 @@
 <svg
 	width={size}
 	height={size}
-	viewBox={`${-boardRadius} ${-boardRadius} ${size} ${size}`}
+	viewBox={viewBox}
 	class="dartboard"
 	data-testid="dartboard"
 >
@@ -196,6 +218,7 @@
 	.dartboard {
 		user-select: none;
 		-webkit-user-select: none;
+		transition: all 0.3s ease;
 	}
 	.dartboard-sector {
 		cursor: pointer;

--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import Dartboard from '$lib/components/dartboard/Dartboard.svelte';
+	import type { Quadrant } from '$lib/components/dartboard/Dartboard.svelte';
 	import ScoreBoard from '$lib/components/scoring/ScoreBoard.svelte';
 	import ScoreKeypad from '$lib/components/scoring/ScoreKeypad.svelte';
 	import ThrowHistory from '$lib/components/scoring/ThrowHistory.svelte';
@@ -44,6 +45,29 @@
 		inputMode = modes[(idx + 1) % modes.length];
 		if (browser) localStorage.setItem(INPUT_MODE_KEY, inputMode);
 	}
+
+	// Quadrant zoom for mobile
+	let activeQuadrant = $state<Quadrant>('full');
+	let isMobile = $state(false);
+
+	$effect(() => {
+		if (!browser) return;
+		const mq = window.matchMedia('(max-width: 499px)');
+		isMobile = mq.matches;
+		function onChange(e: MediaQueryListEvent) {
+			isMobile = e.matches;
+			if (!e.matches) activeQuadrant = 'full';
+		}
+		mq.addEventListener('change', onChange);
+		return () => mq.removeEventListener('change', onChange);
+	});
+
+	const QUADRANTS: { id: Quadrant; label: string; sectors: string }[] = [
+		{ id: 'top-left', label: '↖', sectors: '11/14/9/12/5' },
+		{ id: 'top-right', label: '↗', sectors: '20/1/18/4/13' },
+		{ id: 'bottom-left', label: '↙', sectors: '8/16/7/19/3' },
+		{ id: 'bottom-right', label: '↘', sectors: '6/10/15/2/17' },
+	];
 
 	// Leg history tracking
 	let completedLegs = $state<LegRecord[]>([]);
@@ -418,13 +442,45 @@
 					</button>
 				</div>
 
+				<!-- Quadrant zoom selector (mobile or manual toggle) -->
+				{#if (inputMode === 'dartboard' || inputMode === 'both') && (isMobile || activeQuadrant !== 'full')}
+					<div class="flex items-center gap-1" data-testid="quadrant-selector">
+						<button
+							class="btn btn-xs {activeQuadrant === 'full' ? 'btn-primary' : 'btn-ghost'}"
+							onclick={() => (activeQuadrant = 'full')}
+						>Voll</button>
+						{#each QUADRANTS as q (q.id)}
+							<button
+								class="btn btn-xs {activeQuadrant === q.id ? 'btn-primary' : 'btn-outline'}"
+								onclick={() => (activeQuadrant = q.id)}
+								title={q.sectors}
+							>{q.label}</button>
+						{/each}
+					</div>
+				{/if}
+
 				<!-- Dartboard (shown in dartboard or both mode) -->
 				{#if inputMode === 'dartboard' || inputMode === 'both'}
 					<Dartboard
-						size={inputMode === 'both' ? 280 : 350}
+						size={inputMode === 'both' ? 280 : isMobile ? Math.min(350, 300) : 350}
 						disabled={game.status === 'completed'}
+						quadrant={activeQuadrant}
 						onhit={handleHit}
 					/>
+					<!-- Manual zoom toggle on non-mobile -->
+					{#if !isMobile}
+						<button
+							class="btn btn-ghost btn-xs opacity-50 hover:opacity-100"
+							onclick={() => (activeQuadrant = activeQuadrant === 'full' ? 'top-right' : 'full')}
+							title="Zoom-Modus umschalten"
+							data-testid="zoom-toggle"
+						>
+							<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+								<circle cx="11" cy="11" r="8" /><path stroke-linecap="round" d="M21 21l-4.35-4.35M8 11h6M11 8v6" />
+							</svg>
+							<span class="text-xs">Zoom</span>
+						</button>
+					{/if}
 				{/if}
 
 				<!-- Keypad (shown in keypad or both mode) -->


### PR DESCRIPTION
## Summary

- New `quadrant` prop on `Dartboard` component: `'full' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right'`
- Zoom is purely a `viewBox` change — no new SVG geometry, all existing sector components reused
- Each quadrant shows ~2.5x magnified board quarter with 18% overlap so the bull is always visible/tappable
- **Mobile auto-activation** (viewport < 500px): quadrant selector appears with directional buttons (↖ ↗ ↙ ↘) labeled with sector numbers, plus a "Voll" button
- **Desktop**: small zoom toggle button below the dartboard for manual activation
- Smooth CSS `transition` on the SVG for quadrant switching
- Tablet screens (500–1024px) show the full board at standard size

## Test plan
- [ ] On a phone/narrow viewport (< 500px): quadrant selector appears automatically
- [ ] Tap ↗ — top-right quarter shown zoomed, sectors 20/1/18/4/13 visible and tappable
- [ ] Bull always visible and clickable in every quadrant
- [ ] Tap "Voll" — returns to full board view
- [ ] On desktop: click "Zoom" button below dartboard to enter zoom mode
- [ ] Throws from zoomed view register correctly (same as full board)
- [ ] No layout overflow on 320px wide screens

Closes #5