### PR TITLE
feat: show multiple checkout routes in CheckoutHelper

### DIFF
--- a/src/lib/components/scoring/CheckoutHelper.svelte
+++ b/src/lib/components/scoring/CheckoutHelper.svelte
@@ -1,21 +1,47 @@
 <script lang="ts">
-	import { formatCheckoutRoute, type CheckoutRoute } from '$lib/utils/checkout.js';
+	import type { CheckoutRoute } from '$lib/utils/checkout.js';
 
 	interface Props {
 		remaining: number;
-		checkoutRoute: CheckoutRoute | null;
+		checkoutRoutes: CheckoutRoute[];
 	}
 
-	let { remaining, checkoutRoute }: Props = $props();
+	let { remaining, checkoutRoutes }: Props = $props();
+
+	function dartClass(multiplier: number): string {
+		switch (multiplier) {
+			case 3:
+				return 'bg-warning/20 text-warning border-warning/30';
+			case 2:
+				return 'bg-success/20 text-success border-success/30';
+			default:
+				return 'bg-base-300/50 text-base-content border-base-300';
+		}
+	}
 </script>
 
 <div data-testid="checkout-helper">
-	{#if checkoutRoute}
-		<div class="flex items-center gap-2 p-2 bg-success/10 rounded-lg border border-success/20">
-			<span class="text-xs font-medium text-success">Checkout:</span>
-			<span class="font-mono text-sm font-bold" data-testid="checkout-route">
-				{formatCheckoutRoute(checkoutRoute)}
+	{#if checkoutRoutes.length > 0}
+		<div class="flex flex-col gap-1 p-2 bg-success/10 rounded-lg border border-success/20">
+			<span class="text-xs font-medium text-success">
+				Checkout — {remaining}
 			</span>
+			{#each checkoutRoutes as route, i}
+				<div class="flex items-center gap-1.5" data-testid="checkout-route">
+					<span class="text-xs text-base-content/50 w-4">{i + 1}.</span>
+					{#each route as dart}
+						<span
+							class="px-1.5 py-0.5 text-xs font-mono font-bold rounded border {dartClass(dart.multiplier)}"
+							data-testid="checkout-dart"
+						>
+							{dart.label}
+						</span>
+					{/each}
+					{#if i === 0}
+						<span class="ml-auto text-xs text-warning font-medium" data-testid="optimal-badge">★ Opt</span>
+					{/if}
+				</div>
+			{/each}
 		</div>
 	{:else if remaining <= 170 && remaining > 1}
 		<div class="text-xs text-base-content/40 p-2">Kein Checkout moeglich</div>

--- a/src/lib/stores/game.svelte.ts
+++ b/src/lib/stores/game.svelte.ts
@@ -1,7 +1,7 @@
 import type { Player } from '$lib/types/club.js';
 import type { DartThrow, GameState, Multiplier, SectorValue, SpecialHit } from '$lib/types/game.js';
 import { calcScore, isBust, isCheckout } from '$lib/utils/scoring.js';
-import { getCheckoutRoute, type CheckoutRoute } from '$lib/utils/checkout.js';
+import { getCheckoutRoute, getCheckoutRoutes, type CheckoutRoute } from '$lib/utils/checkout.js';
 
 export function createGameState(config: {
 	match_id: string;
@@ -56,6 +56,11 @@ export function createGameState(config: {
 	const checkoutRoute = $derived.by((): CheckoutRoute | null => {
 		if (status === 'completed') return null;
 		return getCheckoutRoute(currentRemaining);
+	});
+
+	const checkoutRoutes = $derived.by((): CheckoutRoute[] => {
+		if (status === 'completed') return [];
+		return getCheckoutRoutes(currentRemaining);
 	});
 
 	function registerThrow(sector: SectorValue, multiplier: Multiplier): DartThrow {
@@ -222,6 +227,7 @@ export function createGameState(config: {
 		get homeAverage() { return homeAverage; },
 		get awayAverage() { return awayAverage; },
 		get checkoutRoute() { return checkoutRoute; },
+		get checkoutRoutes() { return checkoutRoutes; },
 		get softCheckout() { return softCheckout; },
 		setSoftCheckout(value: boolean) { softCheckout = value; },
 		registerThrow,

--- a/src/lib/utils/checkout.ts
+++ b/src/lib/utils/checkout.ts
@@ -26,24 +26,45 @@ DOUBLES.push({ sector: 25, multiplier: 2, score: 50, label: 'D25' });
 
 const ALL_DARTS: CheckoutDart[] = [...SINGLES, ...DOUBLES, ...TRIPLES];
 
-// Precompute checkout routes for all possible remaining scores (2-170)
-const checkoutTable = new Map<number, CheckoutRoute>();
+// Precompute ALL checkout routes for each remaining score (2-170)
+const allRoutesTable = new Map<number, CheckoutRoute[]>();
 
-function buildCheckoutTable(): void {
+/** Score a route for sorting: fewer darts first, then prefer common doubles (D20, D16, D8). */
+function routeScore(route: CheckoutRoute): number {
+	const dartPenalty = route.length * 1000;
+	const lastDart = route[route.length - 1];
+	// Prefer common finishing doubles: D20(40), D16(32), D8(16), D10(20), D25(50)
+	const preferredDoubles: Record<number, number> = { 40: 0, 32: 1, 16: 2, 20: 3, 50: 4 };
+	const doublePenalty = preferredDoubles[lastDart.score] ?? 10;
+	return dartPenalty + doublePenalty;
+}
+
+/** Create a unique key for a route to deduplicate. */
+function routeKey(route: CheckoutRoute): string {
+	return route.map((d) => d.label).join('-');
+}
+
+function buildAllRoutes(): void {
+	const tempMap = new Map<number, Map<string, CheckoutRoute>>();
+
+	function addRoute(total: number, route: CheckoutRoute) {
+		if (total < 2 || total > 170) return;
+		if (!tempMap.has(total)) tempMap.set(total, new Map());
+		const key = routeKey(route);
+		if (!tempMap.get(total)!.has(key)) {
+			tempMap.get(total)!.set(key, route);
+		}
+	}
+
 	// 1-dart checkouts (just a double)
 	for (const d of DOUBLES) {
-		if (!checkoutTable.has(d.score)) {
-			checkoutTable.set(d.score, [d]);
-		}
+		addRoute(d.score, [d]);
 	}
 
 	// 2-dart checkouts (any + double)
 	for (const first of ALL_DARTS) {
 		for (const finish of DOUBLES) {
-			const total = first.score + finish.score;
-			if (total >= 2 && total <= 170 && !checkoutTable.has(total)) {
-				checkoutTable.set(total, [first, finish]);
-			}
+			addRoute(first.score + finish.score, [first, finish]);
 		}
 	}
 
@@ -51,23 +72,39 @@ function buildCheckoutTable(): void {
 	for (const first of ALL_DARTS) {
 		for (const second of ALL_DARTS) {
 			for (const finish of DOUBLES) {
-				const total = first.score + second.score + finish.score;
-				if (total >= 2 && total <= 170 && !checkoutTable.has(total)) {
-					checkoutTable.set(total, [first, second, finish]);
-				}
+				addRoute(first.score + second.score + finish.score, [first, second, finish]);
 			}
 		}
 	}
+
+	// Sort and store
+	for (const [total, routeMap] of tempMap) {
+		const routes = [...routeMap.values()].sort((a, b) => routeScore(a) - routeScore(b));
+		allRoutesTable.set(total, routes);
+	}
 }
 
-buildCheckoutTable();
+buildAllRoutes();
 
 /**
  * Get the best checkout route for a given remaining score.
  * Returns null if no checkout is possible.
  */
 export function getCheckoutRoute(remaining: number): CheckoutRoute | null {
-	return checkoutTable.get(remaining) ?? null;
+	const routes = allRoutesTable.get(remaining);
+	return routes?.[0] ?? null;
+}
+
+/**
+ * Get multiple checkout routes for a given remaining score, sorted by simplicity.
+ * Returns an empty array if no checkout is possible.
+ * @param remaining - The remaining score
+ * @param maxRoutes - Maximum number of routes to return (default 3)
+ */
+export function getCheckoutRoutes(remaining: number, maxRoutes: number = 3): CheckoutRoute[] {
+	const routes = allRoutesTable.get(remaining);
+	if (!routes) return [];
+	return routes.slice(0, maxRoutes);
 }
 
 /**

--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
@@ -523,7 +523,7 @@
 			</div>
 
 			<div class="flex flex-col gap-4">
-				<CheckoutHelper remaining={game.currentRemaining} checkoutRoute={game.checkoutRoute} />
+				<CheckoutHelper remaining={game.currentRemaining} checkoutRoutes={game.checkoutRoutes} />
 				<ThrowHistory throws={game.throws} currentTurnThrows={game.currentTurnThrows} />
 			</div>
 		</div>

--- a/tests/unit/checkout.test.ts
+++ b/tests/unit/checkout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getCheckoutRoute, formatCheckoutRoute } from '$lib/utils/checkout.js';
+import { getCheckoutRoute, getCheckoutRoutes, formatCheckoutRoute } from '$lib/utils/checkout.js';
 
 describe('Checkout Route Calculator', () => {
 	describe('getCheckoutRoute', () => {
@@ -95,6 +95,79 @@ describe('Checkout Route Calculator', () => {
 					expect(route, `Score ${i} should be impossible`).toBeNull();
 				} else {
 					expect(route, `Score ${i} should have a checkout`).not.toBeNull();
+				}
+			}
+		});
+	});
+
+	describe('getCheckoutRoutes (multiple routes)', () => {
+		it('returns empty array for impossible scores', () => {
+			expect(getCheckoutRoutes(0)).toEqual([]);
+			expect(getCheckoutRoutes(1)).toEqual([]);
+			expect(getCheckoutRoutes(169)).toEqual([]);
+			expect(getCheckoutRoutes(171)).toEqual([]);
+		});
+
+		it('returns 1 route for D1 (2) - only one way', () => {
+			const routes = getCheckoutRoutes(2);
+			expect(routes.length).toBe(1);
+			expect(routes[0].length).toBe(1);
+			expect(routes[0][0].label).toBe('D1');
+		});
+
+		it('returns multiple routes for scores with alternatives', () => {
+			const routes = getCheckoutRoutes(60);
+			expect(routes.length).toBeGreaterThan(1);
+			expect(routes.length).toBeLessThanOrEqual(3);
+		});
+
+		it('respects maxRoutes parameter', () => {
+			const routes1 = getCheckoutRoutes(100, 1);
+			expect(routes1.length).toBe(1);
+
+			const routes5 = getCheckoutRoutes(100, 5);
+			expect(routes5.length).toBeLessThanOrEqual(5);
+			expect(routes5.length).toBeGreaterThanOrEqual(1);
+		});
+
+		it('sorts routes by fewest darts first', () => {
+			const routes = getCheckoutRoutes(40, 3);
+			// D20 (1-dart) should come before any 2-dart route
+			expect(routes[0].length).toBe(1);
+			for (let i = 1; i < routes.length; i++) {
+				expect(routes[i].length).toBeGreaterThanOrEqual(routes[i - 1].length);
+			}
+		});
+
+		it('all routes end on a double', () => {
+			for (let remaining = 2; remaining <= 170; remaining++) {
+				const routes = getCheckoutRoutes(remaining);
+				for (const route of routes) {
+					const lastDart = route[route.length - 1];
+					expect(lastDart.multiplier, `Score ${remaining}: route should end on double`).toBe(2);
+					const total = route.reduce((sum, d) => sum + d.score, 0);
+					expect(total, `Score ${remaining}: route total should match`).toBe(remaining);
+				}
+			}
+		});
+
+		it('returns no duplicate routes', () => {
+			for (let remaining = 2; remaining <= 170; remaining++) {
+				const routes = getCheckoutRoutes(remaining);
+				const labels = routes.map((r) => r.map((d) => d.label).join(' '));
+				const unique = new Set(labels);
+				expect(unique.size, `Score ${remaining}: routes should be unique`).toBe(labels.length);
+			}
+		});
+
+		it('first route matches getCheckoutRoute', () => {
+			for (let remaining = 2; remaining <= 170; remaining++) {
+				const single = getCheckoutRoute(remaining);
+				const multiple = getCheckoutRoutes(remaining);
+				if (single === null) {
+					expect(multiple).toEqual([]);
+				} else {
+					expect(formatCheckoutRoute(multiple[0])).toBe(formatCheckoutRoute(single));
 				}
 			}
 		});


### PR DESCRIPTION
## Summary
- Display up to 3 alternative checkout routes ranked by simplicity (fewest darts first, prefer common doubles D20/D16/D8)
- Each dart shown as a color-coded chip: green for doubles, orange for triples, neutral for singles
- Optimal route badged with ★ Opt marker
- New `getCheckoutRoutes(remaining, maxRoutes)` function with precomputed route table
- Falls back to single row when only one route exists; "Kein Checkout moeglich" state unchanged

Closes #7

## Test plan
- [x] 8 new unit tests for `getCheckoutRoutes()` (all routes end on double, no duplicates, sorted by dart count, respects maxRoutes, matches single-route function)
- [x] All 121 unit tests pass
- [x] svelte-check passes (only pre-existing Buffer error)