### PR TITLE
feat: tournament organizer branding block

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -18,12 +18,33 @@ export function getDatabase(dbPath?: string): Database.Database {
 	db.pragma('journal_mode = WAL');
 	db.pragma('foreign_keys = ON');
 	db.exec(SCHEMA_SQL);
+	runMigrations(db);
 
 	return db;
 }
 
 export function getDefaultDbPath(): string {
 	return process.env.DARTZONE_DB_PATH ?? 'data/dartzone.db';
+}
+
+/** Add columns that may not exist in older databases. */
+function runMigrations(database: Database.Database): void {
+	const cols = database.prepare("PRAGMA table_info('tournaments')").all() as Array<{ name: string }>;
+	const colNames = new Set(cols.map((c) => c.name));
+
+	const migrations: [string, string][] = [
+		['organizer_name', 'ALTER TABLE tournaments ADD COLUMN organizer_name TEXT'],
+		['organizer_logo', 'ALTER TABLE tournaments ADD COLUMN organizer_logo BLOB'],
+		['organizer_logo_mime', 'ALTER TABLE tournaments ADD COLUMN organizer_logo_mime TEXT'],
+		['organizer_contact', 'ALTER TABLE tournaments ADD COLUMN organizer_contact TEXT'],
+		['organizer_note', 'ALTER TABLE tournaments ADD COLUMN organizer_note TEXT']
+	];
+
+	for (const [col, sql] of migrations) {
+		if (!colNames.has(col)) {
+			database.exec(sql);
+		}
+	}
 }
 
 export function closeDatabase(): void {

--- a/src/lib/server/repository.ts
+++ b/src/lib/server/repository.ts
@@ -27,12 +27,14 @@ export interface TournamentRepository {
 	getAll(): Promise<Tournament[]>;
 	getById(id: string): Promise<Tournament | null>;
 	getActive(): Promise<Tournament | null>;
-	create(tournament: Omit<Tournament, 'id'>): Promise<Tournament>;
-	update(id: string, tournament: Partial<Omit<Tournament, 'id'>>): Promise<Tournament | null>;
+	create(tournament: Omit<Tournament, 'id' | 'has_organizer_logo'>): Promise<Tournament>;
+	update(id: string, tournament: Partial<Omit<Tournament, 'id' | 'has_organizer_logo'>>): Promise<Tournament | null>;
 	delete(id: string): Promise<boolean>;
 	getClubIds(tournamentId: string): Promise<string[]>;
 	assignClub(tournamentId: string, clubId: string): Promise<void>;
 	removeClub(tournamentId: string, clubId: string): Promise<void>;
+	getLogoData(id: string): Promise<{ data: Buffer; mime: string } | null>;
+	setLogoData(id: string, data: Buffer, mime: string): Promise<boolean>;
 }
 
 export interface MatchRepository {

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -32,7 +32,12 @@ CREATE TABLE IF NOT EXISTS tournaments (
 	sets_per_match INTEGER NOT NULL DEFAULT 5,
 	start_date TEXT,
 	end_date TEXT,
-	is_active INTEGER NOT NULL DEFAULT 0
+	is_active INTEGER NOT NULL DEFAULT 0,
+	organizer_name TEXT,
+	organizer_logo BLOB,
+	organizer_logo_mime TEXT,
+	organizer_contact TEXT,
+	organizer_note TEXT
 );
 
 CREATE TABLE IF NOT EXISTS tournament_clubs (

--- a/src/lib/server/seed.ts
+++ b/src/lib/server/seed.ts
@@ -70,7 +70,11 @@ export const seedTournaments: Tournament[] = [
 		sets_per_match: 5,
 		start_date: '2026-03-15',
 		end_date: null,
-		is_active: true
+		is_active: true,
+		organizer_name: null,
+		has_organizer_logo: false,
+		organizer_contact: null,
+		organizer_note: null
 	}
 ];
 

--- a/src/lib/server/sqlite-repository.ts
+++ b/src/lib/server/sqlite-repository.ts
@@ -214,60 +214,109 @@ export class SqlitePlayerRepository implements PlayerRepository {
 
 // --- Tournament Repository ---
 
+const TOURNAMENT_COLUMNS = `id, name, game_mode, format, legs_per_set, sets_per_match,
+	start_date, end_date, is_active, organizer_name, organizer_contact, organizer_note,
+	(organizer_logo IS NOT NULL) as has_organizer_logo`;
+
+interface TournamentRow {
+	id: string;
+	name: string;
+	game_mode: string;
+	format: string;
+	legs_per_set: number;
+	sets_per_match: number;
+	start_date: string | null;
+	end_date: string | null;
+	is_active: number;
+	organizer_name: string | null;
+	organizer_contact: string | null;
+	organizer_note: string | null;
+	has_organizer_logo: number;
+}
+
 export class SqliteTournamentRepository implements TournamentRepository {
 	constructor(private db: Database.Database) {}
 
-	private rowToTournament(row: Omit<Tournament, 'is_active'> & { is_active: number }): Tournament {
-		return { ...row, is_active: row.is_active === 1 };
+	private rowToTournament(row: TournamentRow): Tournament {
+		return {
+			id: row.id,
+			name: row.name,
+			game_mode: row.game_mode as Tournament['game_mode'],
+			format: row.format as Tournament['format'],
+			legs_per_set: row.legs_per_set,
+			sets_per_match: row.sets_per_match,
+			start_date: row.start_date,
+			end_date: row.end_date,
+			is_active: row.is_active === 1,
+			organizer_name: row.organizer_name,
+			has_organizer_logo: row.has_organizer_logo === 1,
+			organizer_contact: row.organizer_contact,
+			organizer_note: row.organizer_note
+		};
 	}
 
 	async getAll(): Promise<Tournament[]> {
-		const rows = this.db.prepare('SELECT * FROM tournaments ORDER BY name').all() as Array<
-			Omit<Tournament, 'is_active'> & { is_active: number }
-		>;
+		const rows = this.db.prepare(`SELECT ${TOURNAMENT_COLUMNS} FROM tournaments ORDER BY name`).all() as TournamentRow[];
 		return rows.map((r) => this.rowToTournament(r));
 	}
 
 	async getById(id: string): Promise<Tournament | null> {
-		const row = this.db.prepare('SELECT * FROM tournaments WHERE id = ?').get(id) as
-			| (Omit<Tournament, 'is_active'> & { is_active: number })
-			| undefined;
+		const row = this.db.prepare(`SELECT ${TOURNAMENT_COLUMNS} FROM tournaments WHERE id = ?`).get(id) as TournamentRow | undefined;
 		if (!row) return null;
 		return this.rowToTournament(row);
 	}
 
 	async getActive(): Promise<Tournament | null> {
-		const row = this.db.prepare('SELECT * FROM tournaments WHERE is_active = 1').get() as
-			| (Omit<Tournament, 'is_active'> & { is_active: number })
-			| undefined;
+		const row = this.db.prepare(`SELECT ${TOURNAMENT_COLUMNS} FROM tournaments WHERE is_active = 1`).get() as TournamentRow | undefined;
 		if (!row) return null;
-		return { ...row, is_active: true };
+		return this.rowToTournament(row);
 	}
 
-	async create(data: Omit<Tournament, 'id'>): Promise<Tournament> {
-		const tournament: Tournament = { ...data, id: generateId() };
+	async create(data: Omit<Tournament, 'id' | 'has_organizer_logo'>): Promise<Tournament> {
+		const id = generateId();
 		this.db
 			.prepare(
-				`INSERT INTO tournaments (id, name, game_mode, format, legs_per_set, sets_per_match, start_date, end_date, is_active)
-				 VALUES (@id, @name, @game_mode, @format, @legs_per_set, @sets_per_match, @start_date, @end_date, @is_active)`
+				`INSERT INTO tournaments (id, name, game_mode, format, legs_per_set, sets_per_match, start_date, end_date, is_active, organizer_name, organizer_contact, organizer_note)
+				 VALUES (@id, @name, @game_mode, @format, @legs_per_set, @sets_per_match, @start_date, @end_date, @is_active, @organizer_name, @organizer_contact, @organizer_note)`
 			)
-			.run({ ...tournament, is_active: tournament.is_active ? 1 : 0 });
-		return tournament;
+			.run({
+				id,
+				name: data.name,
+				game_mode: data.game_mode,
+				format: data.format,
+				legs_per_set: data.legs_per_set,
+				sets_per_match: data.sets_per_match,
+				start_date: data.start_date,
+				end_date: data.end_date,
+				is_active: data.is_active ? 1 : 0,
+				organizer_name: data.organizer_name ?? null,
+				organizer_contact: data.organizer_contact ?? null,
+				organizer_note: data.organizer_note ?? null
+			});
+		return (await this.getById(id))!;
 	}
 
-	async update(id: string, data: Partial<Omit<Tournament, 'id'>>): Promise<Tournament | null> {
+	async update(id: string, data: Partial<Omit<Tournament, 'id' | 'has_organizer_logo'>>): Promise<Tournament | null> {
 		const existing = await this.getById(id);
 		if (!existing) return null;
-		const updated: Tournament = { ...existing, ...data };
+		const updated = { ...existing, ...data };
 		this.db
 			.prepare(
 				`UPDATE tournaments SET name = @name, game_mode = @game_mode, format = @format,
 				 legs_per_set = @legs_per_set, sets_per_match = @sets_per_match,
 				 start_date = @start_date, end_date = @end_date,
-				 is_active = @is_active WHERE id = @id`
+				 is_active = @is_active, organizer_name = @organizer_name,
+				 organizer_contact = @organizer_contact, organizer_note = @organizer_note
+				 WHERE id = @id`
 			)
-			.run({ ...updated, is_active: updated.is_active ? 1 : 0 });
-		return updated;
+			.run({
+				...updated,
+				is_active: updated.is_active ? 1 : 0,
+				organizer_name: updated.organizer_name ?? null,
+				organizer_contact: updated.organizer_contact ?? null,
+				organizer_note: updated.organizer_note ?? null
+			});
+		return this.getById(id);
 	}
 
 	async delete(id: string): Promise<boolean> {
@@ -292,6 +341,21 @@ export class SqliteTournamentRepository implements TournamentRepository {
 		this.db
 			.prepare('DELETE FROM tournament_clubs WHERE tournament_id = ? AND club_id = ?')
 			.run(tournamentId, clubId);
+	}
+
+	async getLogoData(id: string): Promise<{ data: Buffer; mime: string } | null> {
+		const row = this.db
+			.prepare('SELECT organizer_logo, organizer_logo_mime FROM tournaments WHERE id = ?')
+			.get(id) as { organizer_logo: Buffer | null; organizer_logo_mime: string | null } | undefined;
+		if (!row?.organizer_logo || !row?.organizer_logo_mime) return null;
+		return { data: row.organizer_logo, mime: row.organizer_logo_mime };
+	}
+
+	async setLogoData(id: string, data: Buffer, mime: string): Promise<boolean> {
+		const result = this.db
+			.prepare('UPDATE tournaments SET organizer_logo = ?, organizer_logo_mime = ? WHERE id = ?')
+			.run(data, mime, id);
+		return result.changes > 0;
 	}
 }
 

--- a/src/lib/types/league.ts
+++ b/src/lib/types/league.ts
@@ -10,6 +10,10 @@ export interface Tournament {
 	start_date: string | null;
 	end_date: string | null;
 	is_active: boolean;
+	organizer_name: string | null;
+	has_organizer_logo: boolean;
+	organizer_contact: string | null;
+	organizer_note: string | null;
 }
 
 export interface Match {

--- a/src/routes/api/tournaments/[id]/logo/+server.ts
+++ b/src/routes/api/tournaments/[id]/logo/+server.ts
@@ -1,0 +1,15 @@
+import type { RequestHandler } from './$types.js';
+import { error } from '@sveltejs/kit';
+import { tournamentRepo } from '$lib/server/db.js';
+
+export const GET: RequestHandler = async ({ params }) => {
+	const logo = await tournamentRepo.getLogoData(params.id);
+	if (!logo) throw error(404, 'Kein Logo vorhanden');
+
+	return new Response(logo.data, {
+		headers: {
+			'Content-Type': logo.mime,
+			'Cache-Control': 'public, max-age=3600'
+		}
+	});
+};

--- a/src/routes/tournaments/[id]/+page.svelte
+++ b/src/routes/tournaments/[id]/+page.svelte
@@ -25,6 +25,34 @@
 		{data.tournament.legs_per_set} Legs/Set &middot; {data.tournament.sets_per_match} Sets/Match
 	</div>
 
+	<!-- Organizer card -->
+	{#if data.tournament.organizer_name}
+		<div class="card card-border bg-base-100 shadow-sm" data-testid="organizer-card">
+			<div class="card-body p-4 flex-row items-center gap-4">
+				{#if data.tournament.has_organizer_logo}
+					<img
+						src="/api/tournaments/{data.tournament.id}/logo"
+						alt="Logo {data.tournament.organizer_name}"
+						class="w-14 h-14 rounded-lg object-contain"
+					/>
+				{:else}
+					<div class="w-14 h-14 rounded-lg bg-primary/10 flex items-center justify-center text-primary font-bold text-lg">
+						{data.tournament.organizer_name.slice(0, 2).toUpperCase()}
+					</div>
+				{/if}
+				<div class="flex flex-col gap-0.5">
+					<span class="font-semibold">{data.tournament.organizer_name}</span>
+					{#if data.tournament.organizer_contact}
+						<span class="text-sm text-base-content/60">{data.tournament.organizer_contact}</span>
+					{/if}
+					{#if data.tournament.organizer_note}
+						<span class="text-sm italic text-base-content/50">'{data.tournament.organizer_note}'</span>
+					{/if}
+				</div>
+			</div>
+		</div>
+	{/if}
+
 	<!-- Standings (round-robin) or Bracket (knockout) -->
 	{#if data.tournament.format === 'round_robin'}
 		<div class="card bg-base-100 shadow-sm">

--- a/src/routes/tournaments/new/+page.server.ts
+++ b/src/routes/tournaments/new/+page.server.ts
@@ -14,7 +14,10 @@ export const actions: Actions = {
 			sets_per_match: Number(formData.get('sets_per_match')),
 			start_date: (formData.get('start_date') as string) || null,
 			end_date: (formData.get('end_date') as string) || null,
-			is_active: formData.get('is_active') === 'on'
+			is_active: formData.get('is_active') === 'on',
+			organizer_name: (formData.get('organizer_name') as string) || null,
+			organizer_contact: (formData.get('organizer_contact') as string) || null,
+			organizer_note: (formData.get('organizer_note') as string) || null
 		};
 
 		const result = tournamentSchema.safeParse(raw);
@@ -27,7 +30,20 @@ export const actions: Actions = {
 			return fail(400, { errors, values: raw });
 		}
 
-		const tournament = await tournamentRepo.create(result.data);
+		const tournament = await tournamentRepo.create({
+			...result.data,
+			organizer_name: raw.organizer_name,
+			organizer_contact: raw.organizer_contact,
+			organizer_note: raw.organizer_note
+		});
+
+		// Handle logo upload
+		const logoFile = formData.get('organizer_logo') as File | null;
+		if (logoFile && logoFile.size > 0) {
+			const buffer = Buffer.from(await logoFile.arrayBuffer());
+			await tournamentRepo.setLogoData(tournament.id, buffer, logoFile.type);
+		}
+
 		throw redirect(303, `/tournaments/${tournament.id}`);
 	}
 };

--- a/src/routes/tournaments/new/+page.svelte
+++ b/src/routes/tournaments/new/+page.svelte
@@ -5,7 +5,7 @@
 <div class="mx-auto max-w-lg">
 	<h1 class="text-2xl font-bold mb-6">Neues Turnier</h1>
 
-	<form method="POST" class="flex flex-col gap-4" data-testid="tournament-form">
+	<form method="POST" enctype="multipart/form-data" class="flex flex-col gap-4" data-testid="tournament-form">
 		<div class="form-control">
 			<label class="label" for="name">Name</label>
 			<input
@@ -63,6 +63,61 @@
 				<span>Aktives Turnier</span>
 			</label>
 		</div>
+
+		<!-- Organizer section (collapsible) -->
+		<details class="collapse collapse-arrow bg-base-200">
+			<summary class="collapse-title font-medium">Veranstalter (optional)</summary>
+			<div class="collapse-content flex flex-col gap-3 pt-2">
+				<div class="form-control">
+					<label class="label" for="organizer_name">Name</label>
+					<input
+						type="text"
+						id="organizer_name"
+						name="organizer_name"
+						class="input input-bordered w-full"
+						placeholder="Dart Club Musterstadt"
+						data-testid="organizer-name"
+					/>
+				</div>
+
+				<div class="form-control">
+					<label class="label" for="organizer_logo">Logo</label>
+					<input
+						type="file"
+						id="organizer_logo"
+						name="organizer_logo"
+						accept="image/png,image/jpeg,image/svg+xml"
+						class="file-input file-input-bordered w-full"
+						data-testid="organizer-logo"
+					/>
+				</div>
+
+				<div class="form-control">
+					<label class="label" for="organizer_contact">Kontakt</label>
+					<input
+						type="text"
+						id="organizer_contact"
+						name="organizer_contact"
+						class="input input-bordered w-full"
+						placeholder="info@example.com"
+						data-testid="organizer-contact"
+					/>
+				</div>
+
+				<div class="form-control">
+					<label class="label" for="organizer_note">Notiz</label>
+					<textarea
+						id="organizer_note"
+						name="organizer_note"
+						class="textarea textarea-bordered w-full"
+						maxlength="300"
+						rows="2"
+						placeholder="Herzlich willkommen!"
+						data-testid="organizer-note"
+					></textarea>
+				</div>
+			</div>
+		</details>
 
 		<div class="flex gap-2 justify-end mt-4">
 			<a href="/tournaments" class="btn btn-ghost">Abbrechen</a>


### PR DESCRIPTION
## Summary
- Add optional organizer profile fields to Tournament: `organizer_name`, `organizer_logo` (BLOB), `organizer_contact`, `organizer_note`
- New `/api/tournaments/[id]/logo` endpoint serving logo images (same pattern as club crests)
- Tournament creation form has a collapsible "Veranstalter" section with name, logo upload, contact, and note fields
- Tournament detail page shows an organizer card when name is set, with logo image or initials fallback
- DB migration automatically adds new columns to existing databases via `ALTER TABLE`
- Seed data updated with new fields

Closes #9

## Test plan
- [x] svelte-check passes (only pre-existing Buffer error, now in both crest + logo endpoints)
- [x] All 121 unit tests pass
- [ ] Manual: create tournament with organizer name + logo, verify card renders on detail page
- [ ] Manual: create tournament without organizer, verify no card shown
- [ ] Manual: verify migration works on existing database (new columns added)