### PR TITLE
feat: add abandon/forfeit match action

### DIFF
--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.server.ts
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.server.ts
@@ -59,5 +59,70 @@ export const actions: Actions = {
 		}
 
 		return { success: true, matchCompleted: update.status === 'completed' };
+	},
+
+	forfeitLeg: async ({ request, params }) => {
+		const formData = await request.formData();
+		const forfeitSide = formData.get('forfeit_side') as 'home' | 'away';
+		if (!forfeitSide) return fail(400, { error: 'Forfeit side required' });
+
+		const match = await matchRepo.getById(params.matchId);
+		if (!match) return fail(404, { error: 'Match not found' });
+
+		// Award leg to opponent
+		const winnerSide = forfeitSide === 'home' ? 'away' : 'home';
+		const update: { home_legs_won?: number; away_legs_won?: number; status?: 'in_progress' | 'completed'; completed_at?: string } = {
+			status: 'in_progress'
+		};
+
+		if (winnerSide === 'home') {
+			update.home_legs_won = match.home_legs_won + 1;
+		} else {
+			update.away_legs_won = match.away_legs_won + 1;
+		}
+
+		const tournament = await tournamentRepo.getById(params.id);
+		const legsToWin = tournament ? Math.ceil(tournament.sets_per_match / 2) : 3;
+		const newHomeLegs = update.home_legs_won ?? match.home_legs_won;
+		const newAwayLegs = update.away_legs_won ?? match.away_legs_won;
+
+		if (newHomeLegs >= legsToWin || newAwayLegs >= legsToWin) {
+			update.status = 'completed';
+			update.completed_at = new Date().toISOString();
+		}
+
+		await matchRepo.update(params.matchId, update);
+
+		if (update.status === 'completed') {
+			await standingsService.recalculate(params.id);
+		}
+
+		return { success: true, matchCompleted: update.status === 'completed', winnerSide };
+	},
+
+	concedeMatch: async ({ request, params }) => {
+		const formData = await request.formData();
+		const forfeitSide = formData.get('forfeit_side') as 'home' | 'away';
+		if (!forfeitSide) return fail(400, { error: 'Forfeit side required' });
+
+		const match = await matchRepo.getById(params.matchId);
+		if (!match) return fail(404, { error: 'Match not found' });
+
+		const tournament = await tournamentRepo.getById(params.id);
+		const legsToWin = tournament ? Math.ceil(tournament.sets_per_match / 2) : 3;
+
+		// Award all remaining legs to opponent
+		const winnerSide = forfeitSide === 'home' ? 'away' : 'home';
+		const update: { home_legs_won: number; away_legs_won: number; status: 'completed'; completed_at: string } = {
+			home_legs_won: winnerSide === 'home' ? legsToWin : match.home_legs_won,
+			away_legs_won: winnerSide === 'away' ? legsToWin : match.away_legs_won,
+			status: 'completed',
+			completed_at: new Date().toISOString()
+		};
+
+		await matchRepo.update(params.matchId, update);
+		await standingsService.recalculate(params.id);
+
+		return { success: true, matchCompleted: true };
 	}
 };

--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
@@ -211,6 +211,117 @@
 		game.undoLastThrow();
 	}
 
+	// Forfeit state
+	let showForfeitDialog = $state(false);
+	let forfeitStep = $state<'choose' | 'confirm-leg' | 'confirm-match'>('choose');
+	let forfeitSaving = $state(false);
+
+	function openForfeitDialog() {
+		forfeitStep = 'choose';
+		showForfeitDialog = true;
+	}
+
+	function closeForfeitDialog() {
+		showForfeitDialog = false;
+		forfeitStep = 'choose';
+	}
+
+	// The side that forfeits is the current player's side
+	const forfeitSide = $derived(
+		game && game.current_player_id === game.home_player.id ? 'home' : 'away'
+	);
+	const opponentClubName = $derived(
+		forfeitSide === 'home' ? data.match.away_club.name : data.match.home_club.name
+	);
+
+	async function handleForfeitLeg() {
+		if (!game || forfeitSaving) return;
+		forfeitSaving = true;
+
+		try {
+			const formData = new FormData();
+			formData.set('forfeit_side', forfeitSide!);
+
+			const response = await fetch('?/forfeitLeg', {
+				method: 'POST',
+				body: formData,
+				headers: { 'x-sveltekit-action': 'true' }
+			});
+
+			if (!response.ok) {
+				console.error('Failed to forfeit leg:', response.status);
+				return;
+			}
+
+			const result = await response.json();
+
+			// Award leg to opponent
+			if (forfeitSide === 'home') {
+				awayLegsWon++;
+			} else {
+				homeLegsWon++;
+			}
+
+			closeForfeitDialog();
+
+			// Check match completion
+			if (result.data?.matchCompleted || homeLegsWon >= legsToWin || awayLegsWon >= legsToWin) {
+				matchCompleted = true;
+				return;
+			}
+
+			// Start next leg
+			legNumber++;
+			game = createGameState({
+				match_id: data.match.id,
+				leg_number: legNumber,
+				home_player: data.homePlayers[homePlayerIndex],
+				away_player: data.awayPlayers[awayPlayerIndex],
+				starting_score: startingScore,
+				softCheckout
+			});
+		} catch (err) {
+			console.error('Error forfeiting leg:', err);
+		} finally {
+			forfeitSaving = false;
+		}
+	}
+
+	async function handleConcedeMatch() {
+		if (!game || forfeitSaving) return;
+		forfeitSaving = true;
+
+		try {
+			const formData = new FormData();
+			formData.set('forfeit_side', forfeitSide!);
+
+			const response = await fetch('?/concedeMatch', {
+				method: 'POST',
+				body: formData,
+				headers: { 'x-sveltekit-action': 'true' }
+			});
+
+			if (!response.ok) {
+				console.error('Failed to concede match:', response.status);
+				return;
+			}
+
+			// Set final score
+			if (forfeitSide === 'home') {
+				awayLegsWon = legsToWin;
+			} else {
+				homeLegsWon = legsToWin;
+			}
+
+			closeForfeitDialog();
+			matchCompleted = true;
+		} catch (err) {
+			console.error('Error conceding match:', err);
+		} finally {
+			forfeitSaving = false;
+		}
+	}
+
 	let legSaving = $state(false);
 
 	async function handleLegComplete() {
@@ -273,9 +384,18 @@
 <div class="flex flex-col gap-4" data-testid="game-page">
 	<div class="flex items-center gap-4">
 		<a href="/tournaments/{data.tournament.id}" class="btn btn-ghost btn-sm">Zurueck</a>
-		<h1 class="text-xl font-bold">
+		<h1 class="text-xl font-bold flex-1">
 			{data.match.home_club.short_name} vs {data.match.away_club.short_name}
 		</h1>
+		{#if matchStarted && !matchCompleted}
+			<button
+				class="btn btn-outline btn-error btn-sm"
+				onclick={openForfeitDialog}
+				data-testid="forfeit-btn"
+			>
+				Aufgeben
+			</button>
+		{/if}
 	</div>
 
 	<!-- Match Score Header -->
@@ -525,6 +645,84 @@
 			<div class="flex flex-col gap-4">
 				<CheckoutHelper remaining={game.currentRemaining} checkoutRoutes={game.checkoutRoutes} />
 				<ThrowHistory throws={game.throws} currentTurnThrows={game.currentTurnThrows} />
+			</div>
+		</div>
+	{/if}
+
+	<!-- Forfeit Dialog -->
+	{#if showForfeitDialog}
+		<div class="modal modal-open" data-testid="forfeit-dialog">
+			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+			<div class="modal-backdrop" onclick={closeForfeitDialog}></div>
+			<div class="modal-box">
+				{#if forfeitStep === 'choose'}
+					<h3 class="font-bold text-lg">Aufgeben</h3>
+					<p class="py-4 text-base-content/70">Was moechtest du aufgeben?</p>
+					<div class="flex flex-col gap-3">
+						<button
+							class="btn btn-outline btn-warning"
+							onclick={() => (forfeitStep = 'confirm-leg')}
+							data-testid="forfeit-leg-option"
+						>
+							Leg aufgeben
+						</button>
+						<button
+							class="btn btn-outline btn-error"
+							onclick={() => (forfeitStep = 'confirm-match')}
+							data-testid="forfeit-match-option"
+						>
+							Match aufgeben
+						</button>
+					</div>
+					<div class="modal-action">
+						<button class="btn btn-ghost" onclick={closeForfeitDialog}>Abbrechen</button>
+					</div>
+
+				{:else if forfeitStep === 'confirm-leg'}
+					<h3 class="font-bold text-lg text-warning">Leg aufgeben?</h3>
+					<p class="py-4">
+						Leg {legNumber} wird <strong>{opponentClubName}</strong> zugesprochen.
+						Das Spiel geht weiter.
+					</p>
+					<div class="modal-action">
+						<button class="btn btn-ghost" onclick={() => (forfeitStep = 'choose')}>Zurueck</button>
+						<button
+							class="btn btn-warning"
+							onclick={handleForfeitLeg}
+							disabled={forfeitSaving}
+							data-testid="forfeit-leg-confirm"
+						>
+							{#if forfeitSaving}
+								<span class="loading loading-spinner loading-xs"></span>
+							{/if}
+							Leg aufgeben
+						</button>
+					</div>
+
+				{:else if forfeitStep === 'confirm-match'}
+					<h3 class="font-bold text-lg text-error">Match aufgeben?</h3>
+					<div class="py-4 flex flex-col gap-2">
+						<p>
+							Das gesamte Match wird <strong>{opponentClubName}</strong> zugesprochen.
+						</p>
+						<p>Alle verbleibenden Legs werden gewertet.</p>
+						<p class="text-error text-sm font-medium">Diese Aktion kann nicht rueckgaengig gemacht werden.</p>
+					</div>
+					<div class="modal-action">
+						<button class="btn btn-ghost" onclick={() => (forfeitStep = 'choose')}>Zurueck</button>
+						<button
+							class="btn btn-error"
+							onclick={handleConcedeMatch}
+							disabled={forfeitSaving}
+							data-testid="forfeit-match-confirm"
+						>
+							{#if forfeitSaving}
+								<span class="loading loading-spinner loading-xs"></span>
+							{/if}
+							Match aufgeben
+						</button>
+					</div>
+				{/if}
 			</div>
 		</div>
 	{/if}


### PR DESCRIPTION
## Summary
- Adds an **Aufgeben** (Forfeit) button to the play page header, visible only during active matches
- Two-step dialog: choose between abandoning the current leg or conceding the entire match, then confirm
- **Leg aufgeben**: awards the current leg to the opponent, starts the next leg
- **Match aufgeben**: sets match result in favour of the opponent (all remaining legs awarded), redirects to tournament

## Implementation
- Two new server actions: `forfeitLeg` and `concedeMatch` in play page server
- Modal dialog with three states: choose, confirm-leg, confirm-match
- Standings are recalculated after match concession

Closes #11

## Test plan
- [ ] Start a match, verify 'Aufgeben' button appears
- [ ] Click 'Aufgeben' → dialog shows two options
- [ ] Choose 'Leg aufgeben' → confirmation step → leg awarded to opponent, next leg starts
- [ ] Choose 'Match aufgeben' → confirmation step → match completed, redirected to tournament
- [ ] Verify standings update correctly after forfeit
- [ ] Verify button not shown on completed matches or before match starts