### PR TITLE
feat: seed color-driven global theming

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,3 +2,19 @@
 @plugin 'daisyui' {
 	themes: light, dark;
 }
+
+/* Smooth color transitions for all interactive elements */
+a, button, .btn, .card, .badge, .menu a, .navbar, input, select, textarea {
+	transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+/* Gradient card surfaces */
+.card {
+	background: linear-gradient(135deg, var(--color-base-100) 0%, var(--color-base-200) 100%);
+}
+
+/* Smooth section dividers */
+.divider-gradient {
+	height: 1px;
+	background: linear-gradient(90deg, transparent, var(--color-base-300), transparent);
+}

--- a/src/lib/components/scoring/ScoreBoard.svelte
+++ b/src/lib/components/scoring/ScoreBoard.svelte
@@ -90,7 +90,7 @@
 
 <div class="grid grid-cols-3 gap-2" data-testid="scoreboard">
 	<div
-		class="card p-4 text-center transition-all duration-300 {homeActive ? 'bg-primary text-primary-content ring-2 ring-primary shadow-lg shadow-primary/20' : 'bg-base-100'}"
+		class="card p-4 text-center transition-all duration-300 {homeActive ? 'bg-gradient-to-br from-primary to-primary/80 text-primary-content ring-2 ring-primary shadow-lg shadow-primary/30' : 'bg-base-100'}"
 		data-testid="scoreboard-home"
 	>
 		<div class="text-sm font-medium truncate" data-testid="scoreboard-home-name">
@@ -140,7 +140,7 @@
 	</div>
 
 	<div
-		class="card p-4 text-center transition-all duration-300 {awayActive ? 'bg-secondary text-secondary-content ring-2 ring-secondary shadow-lg shadow-secondary/20' : 'bg-base-100'}"
+		class="card p-4 text-center transition-all duration-300 {awayActive ? 'bg-gradient-to-br from-secondary to-secondary/80 text-secondary-content ring-2 ring-secondary shadow-lg shadow-secondary/30' : 'bg-base-100'}"
 		data-testid="scoreboard-away"
 	>
 		<div class="text-sm font-medium truncate" data-testid="scoreboard-away-name">

--- a/src/lib/stores/theme.svelte.ts
+++ b/src/lib/stores/theme.svelte.ts
@@ -1,37 +1,105 @@
 import { browser } from '$app/environment';
+import {
+	COLOR_PRESETS,
+	generateLightPalette,
+	generateDarkPalette,
+	paletteToCSSVars,
+	type ColorPreset
+} from '$lib/utils/color.js';
 
-const STORAGE_KEY = 'dartzone-theme';
-const DARK_THEME = 'dark';
-const LIGHT_THEME = 'light';
+const THEME_KEY = 'dartzone-theme';
+const COLORS_KEY = 'dartzone-colors';
+
+export interface ThemeColors {
+	preset: string | null; // preset name, or null for custom
+	primary: string;       // hex
+	accent: string;        // hex
+}
+
+const DEFAULT_PRESET = COLOR_PRESETS[0]; // forest green
+
+function getInitialMode(): 'light' | 'dark' {
+	if (!browser) return 'light';
+	const stored = localStorage.getItem(THEME_KEY);
+	if (stored === 'dark' || stored === 'light') return stored;
+	return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function getInitialColors(): ThemeColors {
+	if (!browser) return { preset: DEFAULT_PRESET.name, primary: DEFAULT_PRESET.primary, accent: DEFAULT_PRESET.accent };
+	const stored = localStorage.getItem(COLORS_KEY);
+	if (stored) {
+		try {
+			const parsed = JSON.parse(stored);
+			if (parsed.primary && parsed.accent) return parsed;
+		} catch { /* ignore */ }
+	}
+	return { preset: DEFAULT_PRESET.name, primary: DEFAULT_PRESET.primary, accent: DEFAULT_PRESET.accent };
+}
 
 export function createThemeStore() {
-	let theme = $state(getInitialTheme());
+	let mode = $state<'light' | 'dark'>(getInitialMode());
+	let colors = $state<ThemeColors>(getInitialColors());
 
-	function getInitialTheme(): string {
-		if (!browser) return LIGHT_THEME;
-		const stored = localStorage.getItem(STORAGE_KEY);
-		if (stored) return stored;
-		return window.matchMedia('(prefers-color-scheme: dark)').matches ? DARK_THEME : LIGHT_THEME;
+	function applyPalette() {
+		if (!browser) return;
+
+		document.documentElement.setAttribute('data-theme', mode);
+
+		const palette = mode === 'dark'
+			? generateDarkPalette(colors.primary, colors.accent)
+			: generateLightPalette(colors.primary, colors.accent);
+
+		const vars = paletteToCSSVars(palette);
+		const root = document.documentElement;
+		for (const [key, value] of Object.entries(vars)) {
+			root.style.setProperty(key, value);
+		}
 	}
 
 	function toggle() {
-		theme = theme === DARK_THEME ? LIGHT_THEME : DARK_THEME;
-		if (browser) {
-			localStorage.setItem(STORAGE_KEY, theme);
-			document.documentElement.setAttribute('data-theme', theme);
-		}
+		mode = mode === 'dark' ? 'light' : 'dark';
+		if (browser) localStorage.setItem(THEME_KEY, mode);
+		applyPalette();
+	}
+
+	function setPreset(presetName: string) {
+		const preset = COLOR_PRESETS.find((p) => p.name === presetName);
+		if (!preset) return;
+		colors = { preset: preset.name, primary: preset.primary, accent: preset.accent };
+		persist();
+		applyPalette();
+	}
+
+	function setCustomColors(primary: string, accent: string) {
+		colors = { preset: null, primary, accent };
+		persist();
+		applyPalette();
+	}
+
+	function resetToDefault() {
+		colors = { preset: DEFAULT_PRESET.name, primary: DEFAULT_PRESET.primary, accent: DEFAULT_PRESET.accent };
+		persist();
+		applyPalette();
+	}
+
+	function persist() {
+		if (browser) localStorage.setItem(COLORS_KEY, JSON.stringify(colors));
 	}
 
 	function apply() {
-		if (browser) {
-			document.documentElement.setAttribute('data-theme', theme);
-		}
+		applyPalette();
 	}
 
 	return {
-		get theme() { return theme; },
-		get isDark() { return theme === DARK_THEME; },
+		get mode() { return mode; },
+		get isDark() { return mode === 'dark'; },
+		get colors() { return colors; },
+		get presets(): ColorPreset[] { return COLOR_PRESETS; },
 		toggle,
+		setPreset,
+		setCustomColors,
+		resetToDefault,
 		apply
 	};
 }

--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -1,0 +1,272 @@
+/**
+ * Color utility for generating a full DaisyUI v5 palette from seed colors.
+ * DaisyUI v5 uses oklch() CSS variables.
+ */
+
+export interface HSL {
+	h: number; // 0-360
+	s: number; // 0-100
+	l: number; // 0-100
+}
+
+/** oklch color representation */
+export interface OKLCH {
+	l: number; // 0-1 (lightness)
+	c: number; // 0-0.4 (chroma)
+	h: number; // 0-360 (hue)
+}
+
+export interface ThemePalette {
+	primary: OKLCH;
+	primaryContent: OKLCH;
+	secondary: OKLCH;
+	secondaryContent: OKLCH;
+	accent: OKLCH;
+	accentContent: OKLCH;
+	neutral: OKLCH;
+	neutralContent: OKLCH;
+	base100: OKLCH;
+	base200: OKLCH;
+	base300: OKLCH;
+	baseContent: OKLCH;
+	info: OKLCH;
+	infoContent: OKLCH;
+	success: OKLCH;
+	successContent: OKLCH;
+	warning: OKLCH;
+	warningContent: OKLCH;
+	error: OKLCH;
+	errorContent: OKLCH;
+}
+
+export interface ColorPreset {
+	name: string;
+	label: string;
+	primary: string; // hex
+	accent: string;  // hex
+}
+
+export const COLOR_PRESETS: ColorPreset[] = [
+	{ name: 'forest', label: 'Waldgruen', primary: '#2d6a4f', accent: '#95d5b2' },
+	{ name: 'royal', label: 'Koenigsblau', primary: '#1d3557', accent: '#a8dadc' },
+	{ name: 'crimson', label: 'Karminrot', primary: '#9b2226', accent: '#f4a261' },
+	{ name: 'gold', label: 'Dunkelgold', primary: '#6b4226', accent: '#e9c46a' },
+	{ name: 'purple', label: 'Violett', primary: '#5a189a', accent: '#c77dff' },
+	{ name: 'teal', label: 'Petrol', primary: '#0d6e6e', accent: '#99e2b4' },
+];
+
+// ─── Hex ↔ sRGB ↔ linear RGB ↔ OKLab ↔ OKLCH conversions ────────────
+
+function hexToRGB(hex: string): [number, number, number] {
+	hex = hex.replace('#', '');
+	return [
+		parseInt(hex.substring(0, 2), 16) / 255,
+		parseInt(hex.substring(2, 4), 16) / 255,
+		parseInt(hex.substring(4, 6), 16) / 255
+	];
+}
+
+function linearize(c: number): number {
+	return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function delinearize(c: number): number {
+	return c <= 0.0031308 ? 12.92 * c : 1.055 * Math.pow(c, 1.0 / 2.4) - 0.055;
+}
+
+function rgbToOKLab(r: number, g: number, b: number): [number, number, number] {
+	const lr = linearize(r);
+	const lg = linearize(g);
+	const lb = linearize(b);
+
+	const l_ = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb);
+	const m_ = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb);
+	const s_ = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
+
+	return [
+		0.2104542553 * l_ + 0.7936177850 * m_ - 0.0040720468 * s_,
+		1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_,
+		0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_
+	];
+}
+
+function oklabToRGB(L: number, a: number, b: number): [number, number, number] {
+	const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+	const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+	const s_ = L - 0.0894841775 * a - 1.2914855480 * b;
+
+	const l = l_ * l_ * l_;
+	const m = m_ * m_ * m_;
+	const s = s_ * s_ * s_;
+
+	return [
+		clamp01(delinearize(+4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s)),
+		clamp01(delinearize(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s)),
+		clamp01(delinearize(-0.0041960863 * l - 0.7034186147 * m + 1.7076147010 * s))
+	];
+}
+
+export function hexToOKLCH(hex: string): OKLCH {
+	const [r, g, b] = hexToRGB(hex);
+	const [L, a, bVal] = rgbToOKLab(r, g, b);
+	const c = Math.sqrt(a * a + bVal * bVal);
+	let h = Math.atan2(bVal, a) * (180 / Math.PI);
+	if (h < 0) h += 360;
+	return { l: L, c, h };
+}
+
+export function oklchToHex(color: OKLCH): string {
+	const hRad = color.h * (Math.PI / 180);
+	const a = color.c * Math.cos(hRad);
+	const b = color.c * Math.sin(hRad);
+	const [r, g, bVal] = oklabToRGB(color.l, a, b);
+	const toHex = (v: number) => Math.round(v * 255).toString(16).padStart(2, '0');
+	return `#${toHex(r)}${toHex(g)}${toHex(bVal)}`;
+}
+
+/** Also keep hex↔HSL for backward compatibility */
+export function hexToHSL(hex: string): HSL {
+	const [r, g, b] = hexToRGB(hex);
+	const max = Math.max(r, g, b);
+	const min = Math.min(r, g, b);
+	const l = (max + min) / 2;
+	let h = 0, s = 0;
+	if (max !== min) {
+		const d = max - min;
+		s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+		switch (max) {
+			case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+			case g: h = ((b - r) / d + 2) / 6; break;
+			case b: h = ((r - g) / d + 4) / 6; break;
+		}
+	}
+	return { h: Math.round(h * 360), s: Math.round(s * 100), l: Math.round(l * 100) };
+}
+
+export function hslToHex(hsl: HSL): string {
+	const h = hsl.h / 360, s = hsl.s / 100, l = hsl.l / 100;
+	function hue2rgb(p: number, q: number, t: number): number {
+		if (t < 0) t += 1; if (t > 1) t -= 1;
+		if (t < 1 / 6) return p + (q - p) * 6 * t;
+		if (t < 1 / 2) return q;
+		if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+		return p;
+	}
+	let r: number, g: number, b: number;
+	if (s === 0) { r = g = b = l; }
+	else {
+		const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+		const p = 2 * l - q;
+		r = hue2rgb(p, q, h + 1 / 3); g = hue2rgb(p, q, h); b = hue2rgb(p, q, h - 1 / 3);
+	}
+	const toHex = (c: number) => Math.round(c * 255).toString(16).padStart(2, '0');
+	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+// ─── Palette generation ────────────────────────────────────────────────
+
+/** Get contrasting content color for a given background */
+function contrastContent(bg: OKLCH): OKLCH {
+	return bg.l > 0.55
+		? { l: 0.25, c: Math.min(bg.c, 0.04), h: bg.h }
+		: { l: 0.95, c: Math.min(bg.c, 0.03), h: bg.h };
+}
+
+/** Generate a full light-mode palette from primary and accent hex colors */
+export function generateLightPalette(primaryHex: string, accentHex: string): ThemePalette {
+	const p = hexToOKLCH(primaryHex);
+	const a = hexToOKLCH(accentHex);
+
+	const primary: OKLCH = { l: clampVal(p.l, 0.35, 0.55), c: Math.min(p.c + 0.02, 0.3), h: p.h };
+	const secondary: OKLCH = { l: clampVal(a.l, 0.45, 0.65), c: Math.min(a.c + 0.01, 0.25), h: a.h };
+	const accent: OKLCH = { l: clampVal(a.l, 0.55, 0.75), c: Math.min(a.c, 0.2), h: a.h };
+	const neutral: OKLCH = { l: 0.25, c: 0.015, h: p.h };
+
+	const base100: OKLCH = { l: 0.98, c: 0.005, h: p.h };
+	const base200: OKLCH = { l: 0.95, c: 0.008, h: p.h };
+	const base300: OKLCH = { l: 0.90, c: 0.010, h: p.h };
+
+	const info: OKLCH = { l: 0.70, c: 0.15, h: (p.h + 200) % 360 };
+	const success: OKLCH = { l: 0.70, c: 0.17, h: 160 };
+	const warning: OKLCH = { l: 0.80, c: 0.18, h: 85 };
+	const error: OKLCH = { l: 0.65, c: 0.20, h: 25 };
+
+	return {
+		primary, primaryContent: contrastContent(primary),
+		secondary, secondaryContent: contrastContent(secondary),
+		accent, accentContent: contrastContent(accent),
+		neutral, neutralContent: { l: 0.90, c: 0.005, h: p.h },
+		base100, base200, base300, baseContent: { l: 0.25, c: 0.015, h: p.h },
+		info, infoContent: contrastContent(info),
+		success, successContent: contrastContent(success),
+		warning, warningContent: contrastContent(warning),
+		error, errorContent: contrastContent(error),
+	};
+}
+
+/** Generate a full dark-mode palette from primary and accent hex colors */
+export function generateDarkPalette(primaryHex: string, accentHex: string): ThemePalette {
+	const p = hexToOKLCH(primaryHex);
+	const a = hexToOKLCH(accentHex);
+
+	const primary: OKLCH = { l: clampVal(p.l + 0.1, 0.50, 0.70), c: Math.min(p.c + 0.02, 0.28), h: p.h };
+	const secondary: OKLCH = { l: clampVal(a.l, 0.55, 0.70), c: Math.min(a.c + 0.01, 0.22), h: a.h };
+	const accent: OKLCH = { l: clampVal(a.l + 0.05, 0.60, 0.75), c: Math.min(a.c, 0.18), h: a.h };
+	const neutral: OKLCH = { l: 0.20, c: 0.015, h: p.h };
+
+	const base100: OKLCH = { l: 0.25, c: 0.015, h: p.h };
+	const base200: OKLCH = { l: 0.22, c: 0.012, h: p.h };
+	const base300: OKLCH = { l: 0.18, c: 0.010, h: p.h };
+
+	const info: OKLCH = { l: 0.72, c: 0.14, h: (p.h + 200) % 360 };
+	const success: OKLCH = { l: 0.72, c: 0.16, h: 160 };
+	const warning: OKLCH = { l: 0.80, c: 0.17, h: 85 };
+	const error: OKLCH = { l: 0.68, c: 0.19, h: 25 };
+
+	return {
+		primary, primaryContent: contrastContent(primary),
+		secondary, secondaryContent: contrastContent(secondary),
+		accent, accentContent: contrastContent(accent),
+		neutral, neutralContent: { l: 0.88, c: 0.005, h: p.h },
+		base100, base200, base300, baseContent: { l: 0.92, c: 0.010, h: p.h },
+		info, infoContent: contrastContent(info),
+		success, successContent: contrastContent(success),
+		warning, warningContent: contrastContent(warning),
+		error, errorContent: contrastContent(error),
+	};
+}
+
+/** Convert a palette to DaisyUI v5 CSS variable overrides (oklch format) */
+export function paletteToCSSVars(palette: ThemePalette): Record<string, string> {
+	function oklchVal(c: OKLCH): string {
+		return `oklch(${(c.l * 100).toFixed(1)}% ${c.c.toFixed(3)} ${c.h.toFixed(1)})`;
+	}
+
+	return {
+		'--color-primary': oklchVal(palette.primary),
+		'--color-primary-content': oklchVal(palette.primaryContent),
+		'--color-secondary': oklchVal(palette.secondary),
+		'--color-secondary-content': oklchVal(palette.secondaryContent),
+		'--color-accent': oklchVal(palette.accent),
+		'--color-accent-content': oklchVal(palette.accentContent),
+		'--color-neutral': oklchVal(palette.neutral),
+		'--color-neutral-content': oklchVal(palette.neutralContent),
+		'--color-base-100': oklchVal(palette.base100),
+		'--color-base-200': oklchVal(palette.base200),
+		'--color-base-300': oklchVal(palette.base300),
+		'--color-base-content': oklchVal(palette.baseContent),
+		'--color-info': oklchVal(palette.info),
+		'--color-info-content': oklchVal(palette.infoContent),
+		'--color-success': oklchVal(palette.success),
+		'--color-success-content': oklchVal(palette.successContent),
+		'--color-warning': oklchVal(palette.warning),
+		'--color-warning-content': oklchVal(palette.warningContent),
+		'--color-error': oklchVal(palette.error),
+		'--color-error-content': oklchVal(palette.errorContent),
+	};
+}
+
+function clamp01(v: number): number { return Math.max(0, Math.min(1, v)); }
+function clampVal(value: number, min: number, max: number): number {
+	return Math.max(min, Math.min(max, value));
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import '../app.css';
+	import { setContext } from 'svelte';
 	import { createThemeStore } from '$lib/stores/theme.svelte.js';
 
 	let { children } = $props();
 	const themeStore = createThemeStore();
+	setContext('theme', themeStore);
 
 	$effect(() => {
 		themeStore.apply();
@@ -15,7 +17,7 @@
 </svelte:head>
 
 <div class="min-h-screen bg-base-200">
-	<nav class="navbar bg-base-100 shadow-sm sticky top-0 z-40">
+	<nav class="navbar bg-gradient-to-r from-base-100 to-base-200 shadow-sm sticky top-0 z-40 border-b border-base-300/50">
 		<div class="flex-1">
 			<a href="/" class="btn btn-ghost text-xl font-bold text-primary">DartZone</a>
 		</div>
@@ -27,6 +29,17 @@
 				<li><a href="/import">Excel-Import</a></li>
 				<li><a href="/export">Backup</a></li>
 			</ul>
+			<a
+				href="/settings"
+				class="btn btn-ghost btn-circle btn-sm"
+				aria-label="Einstellungen"
+				data-testid="settings-link"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.573-1.066z" />
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+				</svg>
+			</a>
 			<button
 				class="btn btn-ghost btn-circle btn-sm"
 				onclick={() => themeStore.toggle()}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { ThemeStore } from '$lib/stores/theme.svelte.js';
+	import { hslToHex, hexToHSL } from '$lib/utils/color.js';
+
+	const theme = getContext<ThemeStore>('theme');
+
+	let customPrimary = $state(theme.colors.primary);
+	let customAccent = $state(theme.colors.accent);
+
+	function applyCustom() {
+		theme.setCustomColors(customPrimary, customAccent);
+	}
+</script>
+
+<div class="mx-auto max-w-2xl">
+	<h1 class="text-2xl font-bold mb-6">Einstellungen</h1>
+
+	<!-- Theme Mode -->
+	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
+		<div class="card-body">
+			<h2 class="card-title">Darstellung</h2>
+			<div class="flex items-center justify-between">
+				<span>Dunkler Modus</span>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary"
+					checked={theme.isDark}
+					onchange={() => theme.toggle()}
+					data-testid="dark-mode-toggle"
+				/>
+			</div>
+		</div>
+	</div>
+
+	<!-- Color Presets -->
+	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
+		<div class="card-body">
+			<h2 class="card-title">Farbschema</h2>
+			<p class="text-sm text-base-content/60 mb-4">Waehle ein vordefiniertes Farbschema oder erstelle ein eigenes.</p>
+
+			<div class="grid grid-cols-2 sm:grid-cols-3 gap-3" data-testid="color-presets">
+				{#each theme.presets as preset (preset.name)}
+					<button
+						class="flex items-center gap-3 p-3 rounded-lg border-2 transition-all duration-200 hover:scale-[1.02]"
+						class:border-primary={theme.colors.preset === preset.name}
+						class:border-base-300={theme.colors.preset !== preset.name}
+						class:shadow-md={theme.colors.preset === preset.name}
+						onclick={() => {
+							theme.setPreset(preset.name);
+							customPrimary = preset.primary;
+							customAccent = preset.accent;
+						}}
+						data-testid="preset-{preset.name}"
+					>
+						<div class="flex gap-1">
+							<div
+								class="w-6 h-6 rounded-full border border-base-300/50"
+								style="background-color: {preset.primary}"
+							></div>
+							<div
+								class="w-6 h-6 rounded-full border border-base-300/50"
+								style="background-color: {preset.accent}"
+							></div>
+						</div>
+						<span class="text-sm font-medium">{preset.label}</span>
+					</button>
+				{/each}
+			</div>
+		</div>
+	</div>
+
+	<!-- Custom Colors -->
+	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
+		<div class="card-body">
+			<h2 class="card-title">Eigene Farben</h2>
+			<div class="flex flex-wrap gap-6">
+				<div class="form-control">
+					<label class="label" for="custom-primary">Primaerfarbe</label>
+					<div class="flex items-center gap-2">
+						<input
+							type="color"
+							id="custom-primary"
+							bind:value={customPrimary}
+							class="w-12 h-10 rounded cursor-pointer border border-base-300"
+							data-testid="custom-primary"
+						/>
+						<span class="text-sm font-mono text-base-content/60">{customPrimary}</span>
+					</div>
+				</div>
+				<div class="form-control">
+					<label class="label" for="custom-accent">Akzentfarbe</label>
+					<div class="flex items-center gap-2">
+						<input
+							type="color"
+							id="custom-accent"
+							bind:value={customAccent}
+							class="w-12 h-10 rounded cursor-pointer border border-base-300"
+							data-testid="custom-accent"
+						/>
+						<span class="text-sm font-mono text-base-content/60">{customAccent}</span>
+					</div>
+				</div>
+			</div>
+			<div class="flex gap-2 mt-4">
+				<button
+					class="btn btn-primary btn-sm"
+					onclick={applyCustom}
+					data-testid="apply-custom-colors"
+				>
+					Uebernehmen
+				</button>
+				<button
+					class="btn btn-ghost btn-sm"
+					onclick={() => theme.resetToDefault()}
+					data-testid="reset-colors"
+				>
+					Zuruecksetzen
+				</button>
+			</div>
+		</div>
+	</div>
+
+	<!-- Preview -->
+	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
+		<div class="card-body">
+			<h2 class="card-title">Vorschau</h2>
+			<div class="flex flex-wrap gap-2">
+				<button class="btn btn-primary btn-sm">Primary</button>
+				<button class="btn btn-secondary btn-sm">Secondary</button>
+				<button class="btn btn-accent btn-sm">Accent</button>
+				<button class="btn btn-info btn-sm">Info</button>
+				<button class="btn btn-success btn-sm">Success</button>
+				<button class="btn btn-warning btn-sm">Warning</button>
+				<button class="btn btn-error btn-sm">Error</button>
+			</div>
+			<div class="flex flex-wrap gap-2 mt-3">
+				<div class="badge badge-primary">Primary</div>
+				<div class="badge badge-secondary">Secondary</div>
+				<div class="badge badge-accent">Accent</div>
+				<div class="badge badge-neutral">Neutral</div>
+			</div>
+			<div class="flex gap-2 mt-3">
+				<div class="w-16 h-8 rounded bg-base-100 border border-base-300 flex items-center justify-center text-xs">100</div>
+				<div class="w-16 h-8 rounded bg-base-200 border border-base-300 flex items-center justify-center text-xs">200</div>
+				<div class="w-16 h-8 rounded bg-base-300 border border-base-300 flex items-center justify-center text-xs">300</div>
+			</div>
+		</div>
+	</div>
+</div>

--- a/tests/unit/color.test.ts
+++ b/tests/unit/color.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import {
+	hexToOKLCH,
+	oklchToHex,
+	hexToHSL,
+	hslToHex,
+	generateLightPalette,
+	generateDarkPalette,
+	paletteToCSSVars,
+	COLOR_PRESETS
+} from '$lib/utils/color.js';
+
+describe('hexToOKLCH', () => {
+	it('converts black to near-zero lightness', () => {
+		const result = hexToOKLCH('#000000');
+		expect(result.l).toBeCloseTo(0, 1);
+		expect(result.c).toBeCloseTo(0, 2);
+	});
+
+	it('converts white to near-one lightness', () => {
+		const result = hexToOKLCH('#ffffff');
+		expect(result.l).toBeCloseTo(1, 1);
+		expect(result.c).toBeCloseTo(0, 2);
+	});
+
+	it('converts a green hex to roughly correct hue', () => {
+		const result = hexToOKLCH('#2d6a4f');
+		expect(result.l).toBeGreaterThan(0.3);
+		expect(result.l).toBeLessThan(0.6);
+		expect(result.c).toBeGreaterThan(0);
+		expect(result.h).toBeGreaterThan(100);
+		expect(result.h).toBeLessThan(200);
+	});
+});
+
+describe('oklchToHex roundtrip', () => {
+	it('roundtrips forest green preset', () => {
+		const original = '#2d6a4f';
+		const oklch = hexToOKLCH(original);
+		const back = oklchToHex(oklch);
+		// Allow small rounding differences
+		const origR = parseInt(original.substring(1, 3), 16);
+		const backR = parseInt(back.substring(1, 3), 16);
+		expect(Math.abs(origR - backR)).toBeLessThanOrEqual(2);
+	});
+
+	it('roundtrips pure red', () => {
+		const oklch = hexToOKLCH('#ff0000');
+		const back = oklchToHex(oklch);
+		const r = parseInt(back.substring(1, 3), 16);
+		expect(r).toBeGreaterThan(250);
+	});
+});
+
+describe('hexToHSL and hslToHex', () => {
+	it('roundtrips correctly', () => {
+		const hex = '#3a86a8';
+		const hsl = hexToHSL(hex);
+		const back = hslToHex(hsl);
+		const origR = parseInt(hex.substring(1, 3), 16);
+		const backR = parseInt(back.substring(1, 3), 16);
+		expect(Math.abs(origR - backR)).toBeLessThanOrEqual(2);
+	});
+});
+
+describe('generateLightPalette', () => {
+	it('returns all expected palette keys', () => {
+		const palette = generateLightPalette('#2d6a4f', '#95d5b2');
+		expect(palette.primary).toBeDefined();
+		expect(palette.base100).toBeDefined();
+		expect(palette.error).toBeDefined();
+	});
+
+	it('has light base colors (high lightness)', () => {
+		const palette = generateLightPalette('#2d6a4f', '#95d5b2');
+		expect(palette.base100.l).toBeGreaterThan(0.9);
+		expect(palette.base200.l).toBeGreaterThan(0.85);
+	});
+
+	it('has dark content color for base', () => {
+		const palette = generateLightPalette('#2d6a4f', '#95d5b2');
+		expect(palette.baseContent.l).toBeLessThan(0.4);
+	});
+});
+
+describe('generateDarkPalette', () => {
+	it('has dark base colors (low lightness)', () => {
+		const palette = generateDarkPalette('#2d6a4f', '#95d5b2');
+		expect(palette.base100.l).toBeLessThan(0.35);
+		expect(palette.base200.l).toBeLessThan(0.3);
+	});
+
+	it('has light content color for base', () => {
+		const palette = generateDarkPalette('#2d6a4f', '#95d5b2');
+		expect(palette.baseContent.l).toBeGreaterThan(0.8);
+	});
+});
+
+describe('paletteToCSSVars', () => {
+	it('generates oklch CSS variable strings', () => {
+		const palette = generateLightPalette('#2d6a4f', '#95d5b2');
+		const vars = paletteToCSSVars(palette);
+
+		expect(vars['--color-primary']).toMatch(/^oklch\(/);
+		expect(vars['--color-base-100']).toMatch(/^oklch\(/);
+		expect(vars['--color-error']).toMatch(/^oklch\(/);
+		expect(Object.keys(vars)).toHaveLength(20);
+	});
+});
+
+describe('COLOR_PRESETS', () => {
+	it('has at least 4 presets', () => {
+		expect(COLOR_PRESETS.length).toBeGreaterThanOrEqual(4);
+	});
+
+	it('all presets have valid hex colors', () => {
+		for (const preset of COLOR_PRESETS) {
+			expect(preset.primary).toMatch(/^#[0-9a-fA-F]{6}$/);
+			expect(preset.accent).toMatch(/^#[0-9a-fA-F]{6}$/);
+			expect(preset.name).toBeTruthy();
+			expect(preset.label).toBeTruthy();
+		}
+	});
+
+	it('all presets generate valid palettes', () => {
+		for (const preset of COLOR_PRESETS) {
+			const light = generateLightPalette(preset.primary, preset.accent);
+			const dark = generateDarkPalette(preset.primary, preset.accent);
+			const lightVars = paletteToCSSVars(light);
+			const darkVars = paletteToCSSVars(dark);
+			expect(Object.keys(lightVars)).toHaveLength(20);
+			expect(Object.keys(darkVars)).toHaveLength(20);
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- **OKLCH color utility** (`src/lib/utils/color.ts`): generates a full 20-variable DaisyUI v5 palette from two seed colors (primary + accent), with proper sRGB→OKLab→OKLCH conversion
- **6 built-in presets**: Waldgruen, Koenigsblau, Karminrot, Dunkelgold, Violett, Petrol
- **Settings page** (`/settings`): preset selector, custom color pickers, dark mode toggle, live preview of all DaisyUI color variants
- **Theme store** rewritten to support seed colors with localStorage persistence, dark/light palette generation
- **Gradient styles**: navbar gradient, card surface gradients, scoreboard active-player gradient glow
- **Smooth transitions**: all interactive elements (buttons, cards, badges, inputs) use CSS transitions
- **15 new unit tests** for color conversion, palette generation, and CSS variable output

Closes #16

## Test plan
- [ ] Visit /settings, verify 6 presets are shown with color swatches
- [ ] Click different presets → entire app palette changes live
- [ ] Pick custom colors → click "Uebernehmen" → palette updates
- [ ] Toggle dark mode → palette regenerates with dark base colors
- [ ] Refresh page → settings persist from localStorage
- [ ] Click "Zuruecksetzen" → returns to default forest green preset
- [ ] Navigate to play page → scoreboard active player has gradient glow
- [ ] Navbar shows subtle gradient background
- [ ] All 136 unit tests pass