### PR TITLE
feat: central settings page with unified store

### DIFF
--- a/src/lib/components/scoring/ScoreBoard.svelte
+++ b/src/lib/components/scoring/ScoreBoard.svelte
@@ -1,22 +1,21 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
+	import { getContext } from 'svelte';
 	import type { GameStore } from '$lib/stores/game.svelte.js';
+	import type { SettingsStore } from '$lib/stores/settings.svelte.js';
 
 	interface Props {
 		game: GameStore;
 	}
 
 	let { game }: Props = $props();
+	const settingsStore = getContext<SettingsStore>('settings');
 
 	const homeActive = $derived(game.current_player_id === game.home_player.id);
 	const awayActive = $derived(game.current_player_id === game.away_player.id);
 
 	// --- Elapsed leg timer ---
-	const TIMER_STORAGE_KEY = 'dartzone_timer_enabled';
-
-	let timerEnabled = $state(
-		browser ? (localStorage.getItem(TIMER_STORAGE_KEY) ?? 'true') !== 'false' : true
-	);
+	let timerEnabled = $state(settingsStore.settings.timerEnabled);
 	let elapsedSeconds = $state(0);
 	let timerStarted = $state(false);
 	let intervalId = $state<ReturnType<typeof setInterval> | null>(null);
@@ -82,7 +81,7 @@
 
 	function toggleTimer() {
 		timerEnabled = !timerEnabled;
-		if (browser) localStorage.setItem(TIMER_STORAGE_KEY, timerEnabled ? 'true' : 'false');
+		settingsStore.update('timerEnabled', timerEnabled);
 		if (!timerEnabled) stopTimer();
 		else if (timerStarted && game.status !== 'completed') startTimer();
 	}

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -1,0 +1,136 @@
+import { browser } from '$app/environment';
+
+const STORAGE_KEY = 'dartzone_settings';
+
+export interface AppSettings {
+	// Animation settings
+	animationsEnabled: boolean;
+	animationBullseye: boolean;
+	animationTripleTwenty: boolean;
+	animationOneEighty: boolean;
+	animationCheckout: boolean;
+
+	// Match defaults
+	defaultGameMode: '501' | '301';
+	defaultSoftCheckout: boolean;
+	defaultLegsPerMatch: number;
+	timerEnabled: boolean;
+
+	// Display
+	inputMode: 'dartboard' | 'keypad' | 'both';
+	showCheckoutHelper: boolean;
+}
+
+const DEFAULTS: AppSettings = {
+	animationsEnabled: true,
+	animationBullseye: true,
+	animationTripleTwenty: true,
+	animationOneEighty: true,
+	animationCheckout: true,
+
+	defaultGameMode: '501',
+	defaultSoftCheckout: false,
+	defaultLegsPerMatch: 5,
+	timerEnabled: true,
+
+	inputMode: 'dartboard',
+	showCheckoutHelper: true,
+};
+
+function loadSettings(): AppSettings {
+	if (!browser) return { ...DEFAULTS };
+	const stored = localStorage.getItem(STORAGE_KEY);
+	if (stored) {
+		try {
+			const parsed = JSON.parse(stored);
+			return { ...DEFAULTS, ...parsed };
+		} catch { /* ignore */ }
+	}
+
+	// Migrate old localStorage keys
+	const migrated = { ...DEFAULTS };
+	const oldTimer = localStorage.getItem('dartzone_timer_enabled');
+	if (oldTimer !== null) {
+		migrated.timerEnabled = oldTimer !== 'false';
+		localStorage.removeItem('dartzone_timer_enabled');
+	}
+	const oldInput = localStorage.getItem('dartzone_input_mode');
+	if (oldInput === 'dartboard' || oldInput === 'keypad' || oldInput === 'both') {
+		migrated.inputMode = oldInput;
+		localStorage.removeItem('dartzone_input_mode');
+	}
+
+	return migrated;
+}
+
+export function createSettingsStore() {
+	let settings = $state<AppSettings>(loadSettings());
+
+	function persist() {
+		if (browser) localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+	}
+
+	function update<K extends keyof AppSettings>(key: K, value: AppSettings[K]) {
+		settings = { ...settings, [key]: value };
+		persist();
+	}
+
+	function resetSection(section: 'animations' | 'match' | 'display') {
+		const keys: Record<string, (keyof AppSettings)[]> = {
+			animations: ['animationsEnabled', 'animationBullseye', 'animationTripleTwenty', 'animationOneEighty', 'animationCheckout'],
+			match: ['defaultGameMode', 'defaultSoftCheckout', 'defaultLegsPerMatch', 'timerEnabled'],
+			display: ['inputMode', 'showCheckoutHelper'],
+		};
+		const reset: Partial<AppSettings> = {};
+		for (const k of keys[section]) {
+			(reset as Record<string, unknown>)[k] = DEFAULTS[k];
+		}
+		settings = { ...settings, ...reset };
+		persist();
+	}
+
+	function resetAll() {
+		settings = { ...DEFAULTS };
+		persist();
+	}
+
+	function exportJSON(): string {
+		return JSON.stringify(settings, null, 2);
+	}
+
+	function importJSON(json: string): boolean {
+		try {
+			const parsed = JSON.parse(json);
+			settings = { ...DEFAULTS, ...parsed };
+			persist();
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	/** Check if a specific animation type is enabled */
+	function isAnimationEnabled(type: string): boolean {
+		if (!settings.animationsEnabled) return false;
+		switch (type) {
+			case 'bullseye': return settings.animationBullseye;
+			case 'triple_twenty': return settings.animationTripleTwenty;
+			case 'one_eighty': return settings.animationOneEighty;
+			case 'checkout': return settings.animationCheckout;
+			default: return true;
+		}
+	}
+
+	return {
+		get settings() { return settings; },
+		get defaults() { return DEFAULTS; },
+		update,
+		resetSection,
+		resetAll,
+		exportJSON,
+		importJSON,
+		isAnimationEnabled,
+	};
+}
+
+export type SettingsStore = ReturnType<typeof createSettingsStore>;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,10 +2,13 @@
 	import '../app.css';
 	import { setContext } from 'svelte';
 	import { createThemeStore } from '$lib/stores/theme.svelte.js';
+	import { createSettingsStore } from '$lib/stores/settings.svelte.js';
 
 	let { children } = $props();
 	const themeStore = createThemeStore();
+	const settingsStore = createSettingsStore();
 	setContext('theme', themeStore);
+	setContext('settings', settingsStore);
 
 	$effect(() => {
 		themeStore.apply();

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,22 +1,54 @@
 <script lang="ts">
 	import { getContext } from 'svelte';
 	import type { ThemeStore } from '$lib/stores/theme.svelte.js';
-	import { hslToHex, hexToHSL } from '$lib/utils/color.js';
+	import type { SettingsStore } from '$lib/stores/settings.svelte.js';
 
 	const theme = getContext<ThemeStore>('theme');
+	const store = getContext<SettingsStore>('settings');
 
 	let customPrimary = $state(theme.colors.primary);
 	let customAccent = $state(theme.colors.accent);
 
-	function applyCustom() {
+	function applyCustomColors() {
 		theme.setCustomColors(customPrimary, customAccent);
+	}
+
+	// Export/Import
+	let importText = $state('');
+	let importError = $state('');
+	let importSuccess = $state(false);
+
+	function handleExport() {
+		const json = store.exportJSON();
+		const blob = new Blob([json], { type: 'application/json' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'dartzone-settings.json';
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
+	function handleImport() {
+		importError = '';
+		importSuccess = false;
+		if (!importText.trim()) {
+			importError = 'Bitte JSON einfuegen';
+			return;
+		}
+		if (store.importJSON(importText)) {
+			importSuccess = true;
+			importText = '';
+		} else {
+			importError = 'Ungueltiges JSON-Format';
+		}
 	}
 </script>
 
 <div class="mx-auto max-w-2xl">
 	<h1 class="text-2xl font-bold mb-6">Einstellungen</h1>
 
-	<!-- Theme Mode -->
+	<!-- Theme / Appearance -->
 	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
 		<div class="card-body">
 			<h2 class="card-title">Darstellung</h2>
@@ -54,97 +86,252 @@
 						data-testid="preset-{preset.name}"
 					>
 						<div class="flex gap-1">
-							<div
-								class="w-6 h-6 rounded-full border border-base-300/50"
-								style="background-color: {preset.primary}"
-							></div>
-							<div
-								class="w-6 h-6 rounded-full border border-base-300/50"
-								style="background-color: {preset.accent}"
-							></div>
+							<div class="w-6 h-6 rounded-full border border-base-300/50" style="background-color: {preset.primary}"></div>
+							<div class="w-6 h-6 rounded-full border border-base-300/50" style="background-color: {preset.accent}"></div>
 						</div>
 						<span class="text-sm font-medium">{preset.label}</span>
 					</button>
 				{/each}
 			</div>
-		</div>
-	</div>
 
-	<!-- Custom Colors -->
-	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
-		<div class="card-body">
-			<h2 class="card-title">Eigene Farben</h2>
+			<div class="divider-gradient my-4"></div>
+
+			<h3 class="font-medium text-sm mb-2">Eigene Farben</h3>
 			<div class="flex flex-wrap gap-6">
 				<div class="form-control">
 					<label class="label" for="custom-primary">Primaerfarbe</label>
 					<div class="flex items-center gap-2">
-						<input
-							type="color"
-							id="custom-primary"
-							bind:value={customPrimary}
-							class="w-12 h-10 rounded cursor-pointer border border-base-300"
-							data-testid="custom-primary"
-						/>
+						<input type="color" id="custom-primary" bind:value={customPrimary} class="w-12 h-10 rounded cursor-pointer border border-base-300" data-testid="custom-primary" />
 						<span class="text-sm font-mono text-base-content/60">{customPrimary}</span>
 					</div>
 				</div>
 				<div class="form-control">
 					<label class="label" for="custom-accent">Akzentfarbe</label>
 					<div class="flex items-center gap-2">
-						<input
-							type="color"
-							id="custom-accent"
-							bind:value={customAccent}
-							class="w-12 h-10 rounded cursor-pointer border border-base-300"
-							data-testid="custom-accent"
-						/>
+						<input type="color" id="custom-accent" bind:value={customAccent} class="w-12 h-10 rounded cursor-pointer border border-base-300" data-testid="custom-accent" />
 						<span class="text-sm font-mono text-base-content/60">{customAccent}</span>
 					</div>
 				</div>
 			</div>
 			<div class="flex gap-2 mt-4">
-				<button
-					class="btn btn-primary btn-sm"
-					onclick={applyCustom}
-					data-testid="apply-custom-colors"
-				>
-					Uebernehmen
-				</button>
-				<button
-					class="btn btn-ghost btn-sm"
-					onclick={() => theme.resetToDefault()}
-					data-testid="reset-colors"
-				>
-					Zuruecksetzen
-				</button>
+				<button class="btn btn-primary btn-sm" onclick={applyCustomColors} data-testid="apply-custom-colors">Uebernehmen</button>
+				<button class="btn btn-ghost btn-sm" onclick={() => theme.resetToDefault()} data-testid="reset-colors">Zuruecksetzen</button>
+			</div>
+
+			<!-- Preview -->
+			<div class="divider-gradient my-4"></div>
+			<h3 class="font-medium text-sm mb-2">Vorschau</h3>
+			<div class="flex flex-wrap gap-2">
+				<button class="btn btn-primary btn-xs">Primary</button>
+				<button class="btn btn-secondary btn-xs">Secondary</button>
+				<button class="btn btn-accent btn-xs">Accent</button>
+				<button class="btn btn-info btn-xs">Info</button>
+				<button class="btn btn-success btn-xs">Success</button>
+				<button class="btn btn-warning btn-xs">Warning</button>
+				<button class="btn btn-error btn-xs">Error</button>
 			</div>
 		</div>
 	</div>
 
-	<!-- Preview -->
+	<!-- Animations -->
 	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
 		<div class="card-body">
-			<h2 class="card-title">Vorschau</h2>
-			<div class="flex flex-wrap gap-2">
-				<button class="btn btn-primary btn-sm">Primary</button>
-				<button class="btn btn-secondary btn-sm">Secondary</button>
-				<button class="btn btn-accent btn-sm">Accent</button>
-				<button class="btn btn-info btn-sm">Info</button>
-				<button class="btn btn-success btn-sm">Success</button>
-				<button class="btn btn-warning btn-sm">Warning</button>
-				<button class="btn btn-error btn-sm">Error</button>
+			<div class="flex items-center justify-between">
+				<h2 class="card-title">Animationen</h2>
+				<button class="btn btn-ghost btn-xs" onclick={() => store.resetSection('animations')}>Zuruecksetzen</button>
 			</div>
-			<div class="flex flex-wrap gap-2 mt-3">
-				<div class="badge badge-primary">Primary</div>
-				<div class="badge badge-secondary">Secondary</div>
-				<div class="badge badge-accent">Accent</div>
-				<div class="badge badge-neutral">Neutral</div>
+
+			<div class="flex items-center justify-between py-2">
+				<div>
+					<span class="font-medium">Alle Animationen</span>
+					<p class="text-xs text-base-content/60">Master-Schalter fuer alle Spielanimationen</p>
+				</div>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary"
+					checked={store.settings.animationsEnabled}
+					onchange={() => store.update('animationsEnabled', !store.settings.animationsEnabled)}
+					data-testid="animations-master-toggle"
+				/>
 			</div>
-			<div class="flex gap-2 mt-3">
-				<div class="w-16 h-8 rounded bg-base-100 border border-base-300 flex items-center justify-center text-xs">100</div>
-				<div class="w-16 h-8 rounded bg-base-200 border border-base-300 flex items-center justify-center text-xs">200</div>
-				<div class="w-16 h-8 rounded bg-base-300 border border-base-300 flex items-center justify-center text-xs">300</div>
+
+			{#if store.settings.animationsEnabled}
+				<div class="flex flex-col gap-2 pl-4 border-l-2 border-base-300">
+					<label class="flex items-center justify-between cursor-pointer py-1">
+						<span class="text-sm">Bullseye (50)</span>
+						<input
+							type="checkbox"
+							class="toggle toggle-sm toggle-primary"
+							checked={store.settings.animationBullseye}
+							onchange={() => store.update('animationBullseye', !store.settings.animationBullseye)}
+							data-testid="anim-bullseye"
+						/>
+					</label>
+					<label class="flex items-center justify-between cursor-pointer py-1">
+						<span class="text-sm">Triple 20</span>
+						<input
+							type="checkbox"
+							class="toggle toggle-sm toggle-primary"
+							checked={store.settings.animationTripleTwenty}
+							onchange={() => store.update('animationTripleTwenty', !store.settings.animationTripleTwenty)}
+							data-testid="anim-triple-twenty"
+						/>
+					</label>
+					<label class="flex items-center justify-between cursor-pointer py-1">
+						<span class="text-sm">180</span>
+						<input
+							type="checkbox"
+							class="toggle toggle-sm toggle-primary"
+							checked={store.settings.animationOneEighty}
+							onchange={() => store.update('animationOneEighty', !store.settings.animationOneEighty)}
+							data-testid="anim-one-eighty"
+						/>
+					</label>
+					<label class="flex items-center justify-between cursor-pointer py-1">
+						<span class="text-sm">Checkout / Sieg</span>
+						<input
+							type="checkbox"
+							class="toggle toggle-sm toggle-primary"
+							checked={store.settings.animationCheckout}
+							onchange={() => store.update('animationCheckout', !store.settings.animationCheckout)}
+							data-testid="anim-checkout"
+						/>
+					</label>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Match Defaults -->
+	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
+		<div class="card-body">
+			<div class="flex items-center justify-between">
+				<h2 class="card-title">Spiel-Standardwerte</h2>
+				<button class="btn btn-ghost btn-xs" onclick={() => store.resetSection('match')}>Zuruecksetzen</button>
 			</div>
+
+			<div class="flex items-center justify-between py-2">
+				<span>Standard-Spielmodus</span>
+				<select
+					class="select select-bordered select-sm w-28"
+					value={store.settings.defaultGameMode}
+					onchange={(e) => store.update('defaultGameMode', (e.target as HTMLSelectElement).value as '501' | '301')}
+					data-testid="default-game-mode"
+				>
+					<option value="501">501</option>
+					<option value="301">301</option>
+				</select>
+			</div>
+
+			<div class="flex items-center justify-between py-2">
+				<div>
+					<span>Einfaches Checkout</span>
+					<p class="text-xs text-base-content/60">Standardmaessig aktiviert fuer neue Spiele</p>
+				</div>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary"
+					checked={store.settings.defaultSoftCheckout}
+					onchange={() => store.update('defaultSoftCheckout', !store.settings.defaultSoftCheckout)}
+					data-testid="default-soft-checkout"
+				/>
+			</div>
+
+			<div class="flex items-center justify-between py-2">
+				<span>Legs pro Match</span>
+				<select
+					class="select select-bordered select-sm w-28"
+					value={store.settings.defaultLegsPerMatch}
+					onchange={(e) => store.update('defaultLegsPerMatch', parseInt((e.target as HTMLSelectElement).value))}
+					data-testid="default-legs"
+				>
+					{#each [1, 3, 5, 7, 9, 11, 13] as n}
+						<option value={n}>Best of {n}</option>
+					{/each}
+				</select>
+			</div>
+
+			<div class="flex items-center justify-between py-2">
+				<span>Leg-Timer</span>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary"
+					checked={store.settings.timerEnabled}
+					onchange={() => store.update('timerEnabled', !store.settings.timerEnabled)}
+					data-testid="default-timer"
+				/>
+			</div>
+		</div>
+	</div>
+
+	<!-- Display -->
+	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
+		<div class="card-body">
+			<div class="flex items-center justify-between">
+				<h2 class="card-title">Anzeige</h2>
+				<button class="btn btn-ghost btn-xs" onclick={() => store.resetSection('display')}>Zuruecksetzen</button>
+			</div>
+
+			<div class="flex items-center justify-between py-2">
+				<span>Eingabemodus</span>
+				<select
+					class="select select-bordered select-sm w-36"
+					value={store.settings.inputMode}
+					onchange={(e) => store.update('inputMode', (e.target as HTMLSelectElement).value as 'dartboard' | 'keypad' | 'both')}
+					data-testid="default-input-mode"
+				>
+					<option value="dartboard">Dartboard</option>
+					<option value="keypad">Tastatur</option>
+					<option value="both">Beides</option>
+				</select>
+			</div>
+
+			<div class="flex items-center justify-between py-2">
+				<span>Checkout-Hilfe anzeigen</span>
+				<input
+					type="checkbox"
+					class="toggle toggle-primary"
+					checked={store.settings.showCheckoutHelper}
+					onchange={() => store.update('showCheckoutHelper', !store.settings.showCheckoutHelper)}
+					data-testid="show-checkout-helper"
+				/>
+			</div>
+		</div>
+	</div>
+
+	<!-- Export / Import -->
+	<div class="card bg-gradient-to-br from-base-100 to-base-200 shadow-sm mb-6">
+		<div class="card-body">
+			<h2 class="card-title">Einstellungen sichern</h2>
+
+			<div class="flex gap-2">
+				<button class="btn btn-outline btn-sm" onclick={handleExport} data-testid="export-settings">
+					Exportieren
+				</button>
+				<button class="btn btn-ghost btn-sm text-error" onclick={() => { store.resetAll(); theme.resetToDefault(); }} data-testid="reset-all">
+					Alles zuruecksetzen
+				</button>
+			</div>
+
+			<div class="divider-gradient my-3"></div>
+
+			<h3 class="font-medium text-sm mb-2">Importieren</h3>
+			<textarea
+				class="textarea textarea-bordered w-full text-xs font-mono"
+				rows="3"
+				placeholder="JSON-Einstellungen hier einfuegen..."
+				bind:value={importText}
+				data-testid="import-textarea"
+			></textarea>
+			{#if importError}
+				<span class="text-error text-xs">{importError}</span>
+			{/if}
+			{#if importSuccess}
+				<span class="text-success text-xs">Einstellungen importiert!</span>
+			{/if}
+			<button class="btn btn-outline btn-sm mt-1" onclick={handleImport} data-testid="import-settings">
+				Importieren
+			</button>
 		</div>
 	</div>
 </div>

--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
@@ -13,10 +13,14 @@
 	import ClubCrest from '$lib/components/clubs/ClubCrest.svelte';
 	import PlayerStatsCard from '$lib/components/scoring/PlayerStatsCard.svelte';
 	import type { PlayerStats } from '$lib/components/scoring/PlayerStatsCard.svelte';
+	import { getContext } from 'svelte';
 	import { createGameState, type GameStore } from '$lib/stores/game.svelte.js';
 	import { createAnimationStore } from '$lib/stores/animation.svelte.js';
+	import type { SettingsStore } from '$lib/stores/settings.svelte.js';
 	import type { DartThrow, Multiplier, SectorValue } from '$lib/types/game.js';
 	import type { Player } from '$lib/types/club.js';
+
+	const settingsStore = getContext<SettingsStore>('settings');
 
 	let { data } = $props();
 
@@ -27,23 +31,20 @@
 	let matchCompleted = $state(data.match.status === 'completed');
 	let homeLegsWon = $state(data.match.home_legs_won);
 	let awayLegsWon = $state(data.match.away_legs_won);
-	let softCheckout = $state(false);
+	let softCheckout = $state(settingsStore.settings.defaultSoftCheckout);
 
 	let game = $state<GameStore | null>(null);
 	const animations = createAnimationStore();
 
-	// Input mode: 'dartboard' | 'keypad' | 'both'
-	const INPUT_MODE_KEY = 'dartzone_input_mode';
+	// Input mode from settings
 	type InputMode = 'dartboard' | 'keypad' | 'both';
-	let inputMode = $state<InputMode>(
-		(browser ? localStorage.getItem(INPUT_MODE_KEY) as InputMode : null) ?? 'dartboard'
-	);
+	let inputMode = $state<InputMode>(settingsStore.settings.inputMode);
 
 	function cycleInputMode() {
 		const modes: InputMode[] = ['dartboard', 'keypad', 'both'];
 		const idx = modes.indexOf(inputMode);
 		inputMode = modes[(idx + 1) % modes.length];
-		if (browser) localStorage.setItem(INPUT_MODE_KEY, inputMode);
+		settingsStore.update('inputMode', inputMode);
 	}
 
 	// Quadrant zoom for mobile
@@ -201,7 +202,7 @@
 		if (!game || game.status === 'completed') return;
 		game.registerThrow(event.sector, event.multiplier);
 
-		if (game.lastSpecialHit) {
+		if (game.lastSpecialHit && settingsStore.isAnimationEnabled(game.lastSpecialHit)) {
 			animations.trigger(game.lastSpecialHit);
 		}
 	}
@@ -643,7 +644,9 @@
 			</div>
 
 			<div class="flex flex-col gap-4">
-				<CheckoutHelper remaining={game.currentRemaining} checkoutRoutes={game.checkoutRoutes} />
+				{#if settingsStore.settings.showCheckoutHelper}
+					<CheckoutHelper remaining={game.currentRemaining} checkoutRoutes={game.checkoutRoutes} />
+				{/if}
 				<ThrowHistory throws={game.throws} currentTurnThrows={game.currentTurnThrows} />
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- **Unified settings store** (`src/lib/stores/settings.svelte.ts`) — single `dartzone_settings` localStorage key replaces scattered keys
- **Settings page** extended with 4 sections: Theme, Animations, Match Defaults, Display
- **Animation controls**: master toggle + per-event toggles (bullseye, T20, 180, checkout)
- **Match defaults**: game mode, soft checkout, legs per match, timer
- **Display**: input mode, checkout helper visibility
- **Export/import** settings as JSON file for sharing between devices
- **Migration**: old localStorage keys (`dartzone_timer_enabled`, `dartzone_input_mode`) auto-migrated
- **Integration**: play page, ScoreBoard, and animation triggers all read from settings store

Closes #17

## Test plan
- [ ] Visit /settings → all 4 sections visible
- [ ] Toggle animation master switch → disables all sub-toggles
- [ ] Toggle individual animation → only that animation disabled during play
- [ ] Change default game mode → new tournaments pick up the default
- [ ] Change input mode in settings → play page respects the choice
- [ ] Toggle checkout helper → hidden/shown on play page
- [ ] Export settings → downloads JSON file
- [ ] Paste JSON and import → settings update immediately
- [ ] Reset section → only that section returns to defaults
- [ ] Reset all → everything returns to defaults
- [ ] All 136 unit tests pass