### PR TITLE
fix: forfeit dialog buttons not responding to clicks

### DIFF
--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
@@ -655,8 +655,6 @@
 	<!-- Forfeit Dialog -->
 	{#if showForfeitDialog}
 		<div class="modal modal-open" data-testid="forfeit-dialog">
-			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-			<div class="modal-backdrop" onclick={closeForfeitDialog}></div>
 			<div class="modal-box">
 				{#if forfeitStep === 'choose'}
 					<h3 class="font-bold text-lg">Aufgeben</h3>
@@ -727,6 +725,8 @@
 					</div>
 				{/if}
 			</div>
+			<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+			<div class="modal-backdrop" onclick={closeForfeitDialog}></div>
 		</div>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary
- Move `modal-backdrop` element after `modal-box` in the DaisyUI v5 modal structure
- In DaisyUI v5, placing the backdrop before the modal-box causes it to intercept all click events on dialog buttons

## Test plan
- [ ] Start a match, click "Aufgeben" button
- [ ] Click "Leg aufgeben" — confirmation step should now appear
- [ ] Click "Match aufgeben" — confirmation step should now appear
- [ ] Clicking the backdrop (outside modal) still closes the dialog

Closes #26