### PR TITLE
feat: Add app version display

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,5 +1,7 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+declare const __APP_VERSION__: string;
+
 declare global {
 	namespace App {
 		// interface Error {}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,7 +22,7 @@
 <div class="min-h-screen bg-base-200">
 	<nav class="navbar bg-gradient-to-r from-base-100 to-base-200 shadow-sm sticky top-0 z-40 border-b border-base-300/50">
 		<div class="flex-1">
-			<a href="/" class="btn btn-ghost text-xl font-bold text-primary">DartZone</a>
+			<a href="/" class="btn btn-ghost text-xl font-bold text-primary" title="DartZone v{__APP_VERSION__}">DartZone</a>
 		</div>
 		<div class="flex-none flex items-center gap-1">
 			<ul class="menu menu-horizontal gap-1">

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -593,4 +593,9 @@
 			</button>
 		</div>
 	</div>
+
+	<!-- Version -->
+	<div class="text-center text-xs text-base-content/40 py-4" data-testid="app-version">
+		DartZone v{__APP_VERSION__}
+	</div>
 </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,14 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vitest/config';
 import { playwright } from '@vitest/browser-playwright';
+import { readFileSync } from 'node:fs';
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
 
 export default defineConfig({
+	define: {
+		__APP_VERSION__: JSON.stringify(pkg.version)
+	},
 	plugins: [tailwindcss(), sveltekit()],
 	test: {
 		projects: [


### PR DESCRIPTION
## Summary
- Inject app version from `package.json` at build time via Vite `define`
- Display version as tooltip on navbar "DartZone" link
- Display version in settings page footer

## Test plan
- [x] Build succeeds with version injection
- [x] All 147 unit tests pass
- [ ] Verify version tooltip appears on hover over "DartZone" in navbar
- [ ] Verify version text appears at bottom of settings page

Closes #30