### PR TITLE
fix: Prevent animation hang during gameplay

### DIFF
--- a/src/lib/components/animations/BullseyeEffect.svelte
+++ b/src/lib/components/animations/BullseyeEffect.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { gsap } from 'gsap';
 	import { createParticles, animateParticleBurst, cleanupParticles } from './animation.utils.js';
 
@@ -11,7 +12,7 @@
 	let container: HTMLElement;
 	let pulseRing: HTMLElement;
 
-	function play() {
+	onMount(() => {
 		const tl = gsap.timeline({
 			onComplete: () => {
 				cleanupParticles(particles);
@@ -30,10 +31,8 @@
 		const particles = createParticles(container, 20, ['#e74c3c', '#c0392b', '#ff6b6b', '#ffd700']);
 		const burstTl = animateParticleBurst(particles, 150);
 		tl.add(burstTl, 0.1);
-	}
 
-	$effect(() => {
-		play();
+		return () => tl.kill();
 	});
 </script>
 

--- a/src/lib/components/animations/CheckoutEffect.svelte
+++ b/src/lib/components/animations/CheckoutEffect.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { gsap } from 'gsap';
 	import { createParticles, cleanupParticles } from './animation.utils.js';
 
@@ -12,7 +13,7 @@
 	let container: HTMLElement;
 	let banner: HTMLElement;
 
-	function play() {
+	onMount(() => {
 		// Confetti particles
 		const confettiColors = [
 			'#e74c3c', '#3498db', '#2ecc71', '#f39c12', '#9b59b6', '#1abc9c', '#ffd700'
@@ -68,10 +69,8 @@
 
 		// Banner fade out
 		tl.to(banner, { y: -50, opacity: 0, duration: 0.5, ease: 'power2.in' }, '+=1');
-	}
 
-	$effect(() => {
-		play();
+		return () => tl.kill();
 	});
 </script>
 

--- a/src/lib/components/animations/OneEightyEffect.svelte
+++ b/src/lib/components/animations/OneEightyEffect.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { gsap } from 'gsap';
 	import { createParticles, animateParticleBurst, cleanupParticles } from './animation.utils.js';
 
@@ -12,7 +13,7 @@
 	let backdrop: HTMLElement;
 	let textEl: HTMLElement;
 
-	function play() {
+	onMount(() => {
 		const particles = createParticles(container, 40, [
 			'#ffd700', '#ffaa00', '#ff8800', '#fff176', '#ffffff'
 		]);
@@ -46,10 +47,8 @@
 		// Fade out
 		tl.to(backdrop, { opacity: 0, duration: 0.5 }, '+=0.5');
 		tl.to(textEl, { scale: 1.5, opacity: 0, duration: 0.5 }, '<');
-	}
 
-	$effect(() => {
-		play();
+		return () => tl.kill();
 	});
 </script>
 

--- a/src/lib/components/animations/TripleTwentyEffect.svelte
+++ b/src/lib/components/animations/TripleTwentyEffect.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { gsap } from 'gsap';
 
 	interface Props {
@@ -11,7 +12,7 @@
 	let textEl: HTMLElement;
 	let streakEl: HTMLElement;
 
-	function play() {
+	onMount(() => {
 		const tl = gsap.timeline({
 			onComplete: () => ondone?.()
 		});
@@ -36,10 +37,8 @@
 			delay: 0.3,
 			ease: 'power1.in'
 		});
-	}
 
-	$effect(() => {
-		play();
+		return () => tl.kill();
 	});
 </script>
 

--- a/src/lib/stores/animation.svelte.ts
+++ b/src/lib/stores/animation.svelte.ts
@@ -6,9 +6,12 @@ export interface AnimationEvent {
 	timestamp: number;
 }
 
+const SAFETY_TIMEOUT_MS = 10_000;
+
 export function createAnimationStore() {
 	let currentEvent = $state<AnimationEvent | null>(null);
 	let isPlaying = $state(false);
+	let safetyTimer: ReturnType<typeof setTimeout> | null = null;
 
 	function trigger(type: SpecialHit) {
 		if (!type || isPlaying) return;
@@ -19,9 +22,16 @@ export function createAnimationStore() {
 			timestamp: Date.now()
 		};
 		isPlaying = true;
+
+		// Safety timeout: auto-dismiss if animation callback never fires
+		safetyTimer = setTimeout(dismiss, SAFETY_TIMEOUT_MS);
 	}
 
 	function dismiss() {
+		if (safetyTimer) {
+			clearTimeout(safetyTimer);
+			safetyTimer = null;
+		}
 		currentEvent = null;
 		isPlaying = false;
 	}


### PR DESCRIPTION
## Summary
- Replace `$effect` with `onMount` in all 4 GSAP animation components to prevent re-triggering
- Add cleanup (`tl.kill()`) on component unmount to prevent orphaned timelines
- Add 10s safety timeout to animation store that auto-dismisses stuck animations

## Root Cause
`$effect` in Svelte 5 tracks reactive dependencies and can re-run unexpectedly, potentially creating duplicate GSAP timelines that interfere with each other. `onMount` runs exactly once and is the correct lifecycle hook for fire-once animations.

## Test plan
- [x] Build succeeds
- [x] 147 unit tests pass
- [ ] Play a game and trigger bullseye/T20/checkout — animation plays and dismisses correctly

Closes #34