### PR TITLE
fix: Rewrite animations with CSS, fix dartboard and scoreboard visuals

### DIFF
--- a/src/lib/components/animations/BullseyeEffect.svelte
+++ b/src/lib/components/animations/BullseyeEffect.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { gsap } from 'gsap';
-	import { createParticles, animateParticleBurst, cleanupParticles } from './animation.utils.js';
 
 	interface Props {
 		ondone?: () => void;
@@ -9,42 +7,67 @@
 
 	let { ondone }: Props = $props();
 
-	let container: HTMLElement;
-	let pulseRing: HTMLElement;
-
 	onMount(() => {
-		const tl = gsap.timeline({
-			onComplete: () => {
-				cleanupParticles(particles);
-				ondone?.();
-			}
-		});
-
-		// Radial pulse from center
-		tl.fromTo(
-			pulseRing,
-			{ scale: 0, opacity: 1 },
-			{ scale: 3, opacity: 0, duration: 0.6, ease: 'power2.out' }
-		);
-
-		// Particle burst
-		const particles = createParticles(container, 20, ['#e74c3c', '#c0392b', '#ff6b6b', '#ffd700']);
-		const burstTl = animateParticleBurst(particles, 150);
-		tl.add(burstTl, 0.1);
-
-		return () => tl.kill();
+		const timer = setTimeout(() => ondone?.(), 2000);
+		return () => clearTimeout(timer);
 	});
 </script>
 
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
-	bind:this={container}
-	class="fixed inset-0 pointer-events-none z-50 flex items-center justify-center"
+	class="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
 	data-testid="bullseye-effect"
+	onclick={() => ondone?.()}
 >
-	<div
-		bind:this={pulseRing}
-		class="w-24 h-24 rounded-full border-4 border-error absolute"
-		style="transform-origin: center;"
-	></div>
-	<div class="text-4xl font-black text-error animate-bounce">BULLSEYE!</div>
+	<div class="bullseye-container">
+		<div class="pulse-ring"></div>
+		<div class="pulse-ring delay-1"></div>
+		<div class="bullseye-text">BULLSEYE!</div>
+	</div>
 </div>
+
+<style>
+	.bullseye-container {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.pulse-ring {
+		position: absolute;
+		width: 120px;
+		height: 120px;
+		border-radius: 50%;
+		border: 4px solid #e74c3c;
+		animation: pulse-expand 1s ease-out forwards;
+	}
+
+	.pulse-ring.delay-1 {
+		animation-delay: 0.3s;
+		opacity: 0;
+	}
+
+	.bullseye-text {
+		font-size: 3rem;
+		font-weight: 900;
+		color: #e74c3c;
+		text-shadow: 0 0 20px rgba(231, 76, 60, 0.8), 0 4px 8px rgba(0, 0, 0, 0.5);
+		animation: text-pop 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards,
+			text-fade 0.5s ease-in 1.5s forwards;
+	}
+
+	@keyframes pulse-expand {
+		0% { transform: scale(0); opacity: 1; }
+		100% { transform: scale(3); opacity: 0; }
+	}
+
+	@keyframes text-pop {
+		0% { transform: scale(0); opacity: 0; }
+		100% { transform: scale(1); opacity: 1; }
+	}
+
+	@keyframes text-fade {
+		to { opacity: 0; transform: scale(1.2); }
+	}
+</style>

--- a/src/lib/components/animations/CheckoutEffect.svelte
+++ b/src/lib/components/animations/CheckoutEffect.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { gsap } from 'gsap';
-	import { createParticles, cleanupParticles } from './animation.utils.js';
 
 	interface Props {
 		playerName?: string;
@@ -10,82 +8,85 @@
 
 	let { playerName = '', ondone }: Props = $props();
 
-	let container: HTMLElement;
-	let banner: HTMLElement;
+	const confetti = Array.from({ length: 30 }, (_, i) => ({
+		id: i,
+		color: ['#e74c3c', '#3498db', '#2ecc71', '#f39c12', '#9b59b6', '#1abc9c', '#ffd700'][i % 7],
+		left: Math.random() * 100,
+		delay: Math.random() * 0.5,
+		duration: 1.5 + Math.random() * 1,
+		drift: (Math.random() - 0.5) * 200,
+		size: 4 + Math.random() * 8,
+		isRect: Math.random() > 0.5
+	}));
 
 	onMount(() => {
-		// Confetti particles
-		const confettiColors = [
-			'#e74c3c', '#3498db', '#2ecc71', '#f39c12', '#9b59b6', '#1abc9c', '#ffd700'
-		];
-		const confetti: HTMLElement[] = [];
-		const rect = container.getBoundingClientRect();
-
-		for (let i = 0; i < 50; i++) {
-			const particle = document.createElement('div');
-			const size = 4 + Math.random() * 8;
-			const isRect = Math.random() > 0.5;
-			particle.style.position = 'absolute';
-			particle.style.width = `${size}px`;
-			particle.style.height = `${isRect ? size * 2 : size}px`;
-			particle.style.borderRadius = isRect ? '2px' : '50%';
-			particle.style.backgroundColor = confettiColors[i % confettiColors.length];
-			particle.style.left = `${Math.random() * rect.width}px`;
-			particle.style.top = '-20px';
-			particle.style.pointerEvents = 'none';
-			container.appendChild(particle);
-			confetti.push(particle);
-		}
-
-		const tl = gsap.timeline({
-			onComplete: () => {
-				cleanupParticles(confetti);
-				ondone?.();
-			}
-		});
-
-		// Confetti fall
-		confetti.forEach((p) => {
-			tl.to(
-				p,
-				{
-					y: rect.height + 40,
-					x: `+=${(Math.random() - 0.5) * 200}`,
-					rotation: Math.random() * 720 - 360,
-					duration: 1.5 + Math.random() * 1,
-					ease: 'power1.in'
-				},
-				Math.random() * 0.3
-			);
-		});
-
-		// Victory banner
-		tl.fromTo(
-			banner,
-			{ y: -100, opacity: 0 },
-			{ y: 0, opacity: 1, duration: 0.5, ease: 'back.out(1.5)' },
-			0
-		);
-
-		// Banner fade out
-		tl.to(banner, { y: -50, opacity: 0, duration: 0.5, ease: 'power2.in' }, '+=1');
-
-		return () => tl.kill();
+		const timer = setTimeout(() => ondone?.(), 3500);
+		return () => clearTimeout(timer);
 	});
 </script>
 
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
-	bind:this={container}
-	class="fixed inset-0 pointer-events-none z-50 flex items-start justify-center pt-20"
+	class="fixed inset-0 z-50 flex items-start justify-center pt-20 overflow-hidden"
 	data-testid="checkout-effect"
+	onclick={() => ondone?.()}
 >
-	<div
-		bind:this={banner}
-		class="bg-success text-success-content px-8 py-4 rounded-2xl shadow-2xl text-center opacity-0"
-	>
+	{#each confetti as c (c.id)}
+		<div
+			class="confetti-piece"
+			style="
+				left: {c.left}%;
+				background-color: {c.color};
+				width: {c.size}px;
+				height: {c.isRect ? c.size * 2 : c.size}px;
+				border-radius: {c.isRect ? '2px' : '50%'};
+				animation-delay: {c.delay}s;
+				animation-duration: {c.duration}s;
+				--drift: {c.drift}px;
+			"
+		></div>
+	{/each}
+
+	<div class="checkout-banner">
 		<div class="text-3xl font-black">CHECKOUT!</div>
 		{#if playerName}
 			<div class="text-lg mt-1">{playerName} gewinnt das Leg!</div>
 		{/if}
 	</div>
 </div>
+
+<style>
+	.confetti-piece {
+		position: absolute;
+		top: -20px;
+		pointer-events: none;
+		animation: confetti-fall linear forwards;
+	}
+
+	.checkout-banner {
+		position: relative;
+		background: oklch(0.72 0.19 142.5);
+		color: white;
+		padding: 1rem 2rem;
+		border-radius: 1rem;
+		box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+		text-align: center;
+		text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+		animation: banner-enter 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards,
+			banner-exit 0.5s ease-in 3s forwards;
+	}
+
+	@keyframes confetti-fall {
+		0% { transform: translateY(0) translateX(0) rotate(0deg); opacity: 1; }
+		100% { transform: translateY(100vh) translateX(var(--drift)) rotate(720deg); opacity: 0; }
+	}
+
+	@keyframes banner-enter {
+		0% { transform: translateY(-100px); opacity: 0; }
+		100% { transform: translateY(0); opacity: 1; }
+	}
+
+	@keyframes banner-exit {
+		to { transform: translateY(-50px); opacity: 0; }
+	}
+</style>

--- a/src/lib/components/animations/OneEightyEffect.svelte
+++ b/src/lib/components/animations/OneEightyEffect.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { gsap } from 'gsap';
-	import { createParticles, animateParticleBurst, cleanupParticles } from './animation.utils.js';
 
 	interface Props {
 		ondone?: () => void;
@@ -9,64 +7,62 @@
 
 	let { ondone }: Props = $props();
 
-	let container: HTMLElement;
-	let backdrop: HTMLElement;
-	let textEl: HTMLElement;
-
 	onMount(() => {
-		const particles = createParticles(container, 40, [
-			'#ffd700', '#ffaa00', '#ff8800', '#fff176', '#ffffff'
-		]);
-
-		const tl = gsap.timeline({
-			onComplete: () => {
-				cleanupParticles(particles);
-				ondone?.();
-			}
-		});
-
-		// Golden backdrop flash
-		tl.fromTo(
-			backdrop,
-			{ opacity: 0 },
-			{ opacity: 0.4, duration: 0.2, ease: 'power2.out' }
-		);
-
-		// Big "180!" text entrance
-		tl.fromTo(
-			textEl,
-			{ scale: 0, rotation: -30, opacity: 0 },
-			{ scale: 1, rotation: 0, opacity: 1, duration: 0.5, ease: 'elastic.out(1, 0.5)' },
-			0.1
-		);
-
-		// Particle burst
-		const burstTl = animateParticleBurst(particles, 250);
-		tl.add(burstTl, 0.2);
-
-		// Fade out
-		tl.to(backdrop, { opacity: 0, duration: 0.5 }, '+=0.5');
-		tl.to(textEl, { scale: 1.5, opacity: 0, duration: 0.5 }, '<');
-
-		return () => tl.kill();
+		const timer = setTimeout(() => ondone?.(), 2500);
+		return () => clearTimeout(timer);
 	});
 </script>
 
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
-	bind:this={container}
-	class="fixed inset-0 pointer-events-none z-50 flex items-center justify-center"
+	class="fixed inset-0 z-50 flex items-center justify-center"
 	data-testid="one-eighty-effect"
+	onclick={() => ondone?.()}
 >
-	<div
-		bind:this={backdrop}
-		class="absolute inset-0 opacity-0"
-		style="background: radial-gradient(circle, rgba(255,215,0,0.6) 0%, transparent 70%);"
-	></div>
-	<div
-		bind:this={textEl}
-		class="text-8xl font-black opacity-0"
-		style="color: #ffd700; text-shadow: 0 0 40px rgba(255,215,0,0.8), 0 4px 8px rgba(0,0,0,0.3);"
-	>
-		180!
-	</div>
+	<div class="backdrop"></div>
+	<div class="one-eighty-text">180!</div>
 </div>
+
+<style>
+	.backdrop {
+		position: absolute;
+		inset: 0;
+		background: radial-gradient(circle, rgba(255, 215, 0, 0.5) 0%, transparent 70%);
+		animation: backdrop-flash 0.3s ease-out forwards, backdrop-fade 0.5s ease-in 2s forwards;
+	}
+
+	.one-eighty-text {
+		position: relative;
+		font-size: 6rem;
+		font-weight: 900;
+		color: #ffd700;
+		text-shadow: 0 0 40px rgba(255, 215, 0, 0.8), 0 0 80px rgba(255, 215, 0, 0.4),
+			0 4px 8px rgba(0, 0, 0, 0.5);
+		animation: text-entrance 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.1s both,
+			text-glow 1s ease-in-out 0.6s 2,
+			text-exit 0.5s ease-in 2s forwards;
+	}
+
+	@keyframes backdrop-flash {
+		0% { opacity: 0; }
+		100% { opacity: 1; }
+	}
+
+	@keyframes backdrop-fade {
+		to { opacity: 0; }
+	}
+
+	@keyframes text-entrance {
+		0% { transform: scale(0) rotate(-30deg); opacity: 0; }
+		100% { transform: scale(1) rotate(0deg); opacity: 1; }
+	}
+
+	@keyframes text-glow {
+		0%, 100% { text-shadow: 0 0 40px rgba(255, 215, 0, 0.8), 0 0 80px rgba(255, 215, 0, 0.4), 0 4px 8px rgba(0, 0, 0, 0.5); }
+		50% { text-shadow: 0 0 60px rgba(255, 215, 0, 1), 0 0 120px rgba(255, 215, 0, 0.6), 0 4px 8px rgba(0, 0, 0, 0.5); }
+	}
+
+	@keyframes text-exit {
+		to { transform: scale(1.5); opacity: 0; }
+	}
+</style>

--- a/src/lib/components/animations/TripleTwentyEffect.svelte
+++ b/src/lib/components/animations/TripleTwentyEffect.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { gsap } from 'gsap';
 
 	interface Props {
 		ondone?: () => void;
@@ -8,55 +7,53 @@
 
 	let { ondone }: Props = $props();
 
-	let container: HTMLElement;
-	let textEl: HTMLElement;
-	let streakEl: HTMLElement;
-
 	onMount(() => {
-		const tl = gsap.timeline({
-			onComplete: () => ondone?.()
-		});
-
-		// Fire streak across the screen
-		tl.fromTo(
-			streakEl,
-			{ x: '-100%', opacity: 0.8, scaleX: 0.5 },
-			{ x: '100vw', opacity: 0, scaleX: 2, duration: 0.6, ease: 'power2.in' }
-		);
-
-		// Text pop
-		tl.fromTo(
-			textEl,
-			{ scale: 0, rotation: -15 },
-			{ scale: 1.2, rotation: 0, duration: 0.3, ease: 'back.out(2)' },
-			0.1
-		).to(textEl, {
-			scale: 1,
-			opacity: 0,
-			duration: 0.5,
-			delay: 0.3,
-			ease: 'power1.in'
-		});
-
-		return () => tl.kill();
+		const timer = setTimeout(() => ondone?.(), 1800);
+		return () => clearTimeout(timer);
 	});
 </script>
 
+<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
-	bind:this={container}
-	class="fixed inset-0 pointer-events-none z-50 flex items-center justify-center"
+	class="fixed inset-0 z-50 flex items-center justify-center bg-black/20"
 	data-testid="triple-twenty-effect"
+	onclick={() => ondone?.()}
 >
-	<div
-		bind:this={streakEl}
-		class="absolute h-2 w-48 top-1/2"
-		style="background: linear-gradient(90deg, transparent, #ff6600, #ff3300, transparent); filter: blur(2px);"
-	></div>
-	<div
-		bind:this={textEl}
-		class="text-4xl font-black"
-		style="color: #ff6600; text-shadow: 0 0 20px rgba(255,102,0,0.5);"
-	>
-		T20!
-	</div>
+	<div class="streak"></div>
+	<div class="t20-text">T20!</div>
 </div>
+
+<style>
+	.streak {
+		position: absolute;
+		height: 4px;
+		width: 200px;
+		top: 50%;
+		background: linear-gradient(90deg, transparent, #ff6600, #ff3300, transparent);
+		filter: blur(2px);
+		animation: streak-move 0.6s ease-in forwards;
+	}
+
+	.t20-text {
+		font-size: 3rem;
+		font-weight: 900;
+		color: #ff6600;
+		text-shadow: 0 0 20px rgba(255, 102, 0, 0.8), 0 4px 8px rgba(0, 0, 0, 0.5);
+		animation: text-pop 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275) 0.1s both,
+			text-fade 0.5s ease-in 1.3s forwards;
+	}
+
+	@keyframes streak-move {
+		0% { transform: translateX(-100vw); opacity: 0.8; }
+		100% { transform: translateX(100vw); opacity: 0; }
+	}
+
+	@keyframes text-pop {
+		0% { transform: scale(0) rotate(-15deg); opacity: 0; }
+		100% { transform: scale(1.2) rotate(0deg); opacity: 1; }
+	}
+
+	@keyframes text-fade {
+		to { opacity: 0; transform: scale(1); }
+	}
+</style>

--- a/src/lib/components/dartboard/Dartboard.svelte
+++ b/src/lib/components/dartboard/Dartboard.svelte
@@ -35,21 +35,24 @@
 	const boardRadius = $derived(size / 2);
 
 	// Quadrant viewBox: show a quarter of the board with overlap so the bull is always visible
+	// LABEL_PAD accounts for number labels placed outside the board ring
 	const OVERLAP = 0.18;
+	const LABEL_PAD = 0.15;
 	const viewBox = $derived.by(() => {
 		const R = boardRadius;
 		const pad = R * OVERLAP;
+		const lp = R * LABEL_PAD;
 		switch (quadrant) {
 			case 'top-left':
-				return `${-R} ${-R} ${R + pad} ${R + pad}`;
+				return `${-R - lp} ${-R - lp} ${R + pad + lp} ${R + pad + lp}`;
 			case 'top-right':
-				return `${-pad} ${-R} ${R + pad} ${R + pad}`;
+				return `${-pad} ${-R - lp} ${R + pad + lp} ${R + pad + lp}`;
 			case 'bottom-left':
-				return `${-R} ${-pad} ${R + pad} ${R + pad}`;
+				return `${-R - lp} ${-pad} ${R + pad + lp} ${R + pad + lp}`;
 			case 'bottom-right':
-				return `${-pad} ${-pad} ${R + pad} ${R + pad}`;
+				return `${-pad} ${-pad} ${R + pad + lp} ${R + pad + lp}`;
 			default:
-				return `${-R} ${-R} ${size} ${size}`;
+				return `${-R - lp} ${-R - lp} ${size + lp * 2} ${size + lp * 2}`;
 		}
 	});
 
@@ -196,13 +199,30 @@
 	{#each SECTOR_ORDER as num, i}
 		{@const angle = ((i * 18 - 90) * Math.PI) / 180}
 		{@const labelRadius = boardRadius * 1.08}
+		{@const lx = labelRadius * Math.cos(angle)}
+		{@const ly = labelRadius * Math.sin(angle)}
+		<!-- Text outline for readability -->
 		<text
-			x={labelRadius * Math.cos(angle)}
-			y={labelRadius * Math.sin(angle)}
+			x={lx}
+			y={ly}
+			text-anchor="middle"
+			dominant-baseline="central"
+			fill="none"
+			stroke="#000"
+			stroke-width={boardRadius * 0.015}
+			font-size={boardRadius * 0.09}
+			font-weight="bold"
+			font-family="Arial, sans-serif"
+		>
+			{num}
+		</text>
+		<text
+			x={lx}
+			y={ly}
 			text-anchor="middle"
 			dominant-baseline="central"
 			fill="white"
-			font-size={boardRadius * 0.08}
+			font-size={boardRadius * 0.09}
 			font-weight="bold"
 			font-family="Arial, sans-serif"
 		>

--- a/src/lib/components/scoring/ScoreBoard.svelte
+++ b/src/lib/components/scoring/ScoreBoard.svelte
@@ -89,13 +89,13 @@
 
 <div class="grid grid-cols-3 gap-2" data-testid="scoreboard">
 	<div
-		class="card p-4 text-center transition-all duration-300 {homeActive ? 'bg-gradient-to-br from-primary to-primary/80 text-primary-content ring-2 ring-primary shadow-lg shadow-primary/30' : 'bg-base-100'}"
+		class="card p-4 text-center transition-all duration-300 {homeActive ? 'bg-base-100 ring-2 ring-primary shadow-lg shadow-primary/30' : 'bg-base-100'}"
 		data-testid="scoreboard-home"
 	>
-		<div class="text-sm font-medium truncate" data-testid="scoreboard-home-name">
+		<div class="text-sm font-medium truncate {homeActive ? 'text-primary' : ''}" data-testid="scoreboard-home-name">
 			{game.home_player.first_name} {game.home_player.last_name}
 		</div>
-		<div class="text-4xl font-bold my-2 tabular-nums" data-testid="scoreboard-home-remaining">
+		<div class="text-4xl font-bold my-2 tabular-nums {homeActive ? 'text-primary' : ''}" data-testid="scoreboard-home-remaining">
 			{game.home_remaining}
 		</div>
 		<div class="text-xs opacity-70" data-testid="scoreboard-home-avg">
@@ -139,13 +139,13 @@
 	</div>
 
 	<div
-		class="card p-4 text-center transition-all duration-300 {awayActive ? 'bg-gradient-to-br from-secondary to-secondary/80 text-secondary-content ring-2 ring-secondary shadow-lg shadow-secondary/30' : 'bg-base-100'}"
+		class="card p-4 text-center transition-all duration-300 {awayActive ? 'bg-base-100 ring-2 ring-secondary shadow-lg shadow-secondary/30' : 'bg-base-100'}"
 		data-testid="scoreboard-away"
 	>
-		<div class="text-sm font-medium truncate" data-testid="scoreboard-away-name">
+		<div class="text-sm font-medium truncate {awayActive ? 'text-secondary' : ''}" data-testid="scoreboard-away-name">
 			{game.away_player.first_name} {game.away_player.last_name}
 		</div>
-		<div class="text-4xl font-bold my-2 tabular-nums" data-testid="scoreboard-away-remaining">
+		<div class="text-4xl font-bold my-2 tabular-nums {awayActive ? 'text-secondary' : ''}" data-testid="scoreboard-away-remaining">
 			{game.away_remaining}
 		</div>
 		<div class="text-xs opacity-70" data-testid="scoreboard-away-avg">

--- a/src/lib/stores/animation.svelte.ts
+++ b/src/lib/stores/animation.svelte.ts
@@ -6,7 +6,7 @@ export interface AnimationEvent {
 	timestamp: number;
 }
 
-const SAFETY_TIMEOUT_MS = 10_000;
+const SAFETY_TIMEOUT_MS = 5_000;
 
 export function createAnimationStore() {
 	let currentEvent = $state<AnimationEvent | null>(null);


### PR DESCRIPTION
## Summary
- Replace all GSAP-based animation effects with pure CSS animations — GSAP was failing silently in production causing stuck overlays
- All animation effects now auto-dismiss via `setTimeout` and are click-to-dismiss
- Expand dartboard SVG viewBox to properly include sector number labels
- Add black text outline to dartboard numbers for readability
- Fix scoreboard active player: use ring highlight instead of background gradient that caused unreadable text

## Test plan
- [x] Build succeeds
- [x] 147 unit tests pass
- [ ] Animations play and dismiss correctly (bullseye, T20, 180, checkout)
- [ ] Dartboard numbers fully visible and readable
- [ ] Scoreboard scores readable for both active and inactive players

Closes #36