### PR TITLE
fix: game stuck after special hits + add miss button (#38)

### DIFF
--- a/src/lib/components/animations/BullseyeEffect.svelte
+++ b/src/lib/components/animations/BullseyeEffect.svelte
@@ -15,9 +15,8 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
-	class="fixed inset-0 z-50 flex items-center justify-center bg-black/30"
+	class="fixed inset-0 z-50 flex items-center justify-center bg-black/30 pointer-events-none"
 	data-testid="bullseye-effect"
-	onclick={() => ondone?.()}
 >
 	<div class="bullseye-container">
 		<div class="pulse-ring"></div>
@@ -32,6 +31,10 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
+	}
+
+	.pointer-events-none {
+		pointer-events: none;
 	}
 
 	.pulse-ring {

--- a/src/lib/components/animations/CheckoutEffect.svelte
+++ b/src/lib/components/animations/CheckoutEffect.svelte
@@ -27,9 +27,8 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
-	class="fixed inset-0 z-50 flex items-start justify-center pt-20 overflow-hidden"
+	class="fixed inset-0 z-50 flex items-start justify-center pt-20 overflow-hidden pointer-events-none"
 	data-testid="checkout-effect"
-	onclick={() => ondone?.()}
 >
 	{#each confetti as c (c.id)}
 		<div
@@ -56,6 +55,10 @@
 </div>
 
 <style>
+	.pointer-events-none {
+		pointer-events: none;
+	}
+
 	.confetti-piece {
 		position: absolute;
 		top: -20px;

--- a/src/lib/components/animations/CustomAnimationPlayer.svelte
+++ b/src/lib/components/animations/CustomAnimationPlayer.svelte
@@ -32,8 +32,7 @@
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-	class="fixed inset-0 z-50 flex justify-center {positionClass} bg-black/40 backdrop-blur-sm"
-	onclick={ondone}
+	class="fixed inset-0 z-50 flex justify-center {positionClass} bg-black/40 backdrop-blur-sm pointer-events-none"
 	data-testid="custom-animation-overlay"
 >
 	{#if isVideo}

--- a/src/lib/components/animations/OneEightyEffect.svelte
+++ b/src/lib/components/animations/OneEightyEffect.svelte
@@ -15,15 +15,18 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
-	class="fixed inset-0 z-50 flex items-center justify-center"
+	class="fixed inset-0 z-50 flex items-center justify-center pointer-events-none"
 	data-testid="one-eighty-effect"
-	onclick={() => ondone?.()}
 >
 	<div class="backdrop"></div>
 	<div class="one-eighty-text">180!</div>
 </div>
 
 <style>
+	.pointer-events-none {
+		pointer-events: none;
+	}
+
 	.backdrop {
 		position: absolute;
 		inset: 0;

--- a/src/lib/components/animations/TripleTwentyEffect.svelte
+++ b/src/lib/components/animations/TripleTwentyEffect.svelte
@@ -15,15 +15,18 @@
 
 <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 <div
-	class="fixed inset-0 z-50 flex items-center justify-center bg-black/20"
+	class="fixed inset-0 z-50 flex items-center justify-center bg-black/20 pointer-events-none"
 	data-testid="triple-twenty-effect"
-	onclick={() => ondone?.()}
 >
 	<div class="streak"></div>
 	<div class="t20-text">T20!</div>
 </div>
 
 <style>
+	.pointer-events-none {
+		pointer-events: none;
+	}
+
 	.streak {
 		position: absolute;
 		height: 4px;

--- a/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
+++ b/src/routes/tournaments/[id]/matches/[matchId]/play/+page.svelte
@@ -200,11 +200,19 @@
 
 	function handleHit(event: { sector: SectorValue; multiplier: Multiplier; score: number }) {
 		if (!game || game.status === 'completed') return;
-		game.registerThrow(event.sector, event.multiplier);
+		try {
+			game.registerThrow(event.sector, event.multiplier);
 
-		if (game.lastSpecialHit && settingsStore.isAnimationEnabled(game.lastSpecialHit)) {
-			animations.trigger(game.lastSpecialHit);
+			if (game.lastSpecialHit && settingsStore.isAnimationEnabled(game.lastSpecialHit)) {
+				animations.trigger(game.lastSpecialHit);
+			}
+		} catch (err) {
+			console.error('Error registering throw:', err);
 		}
+	}
+
+	function handleMiss() {
+		handleHit({ sector: 0 as SectorValue, multiplier: 0 as Multiplier, score: 0 });
 	}
 
 	function handleUndo() {
@@ -588,20 +596,28 @@
 						quadrant={activeQuadrant}
 						onhit={handleHit}
 					/>
-					<!-- Manual zoom toggle on non-mobile -->
-					{#if !isMobile}
+					<div class="flex items-center gap-2">
 						<button
-							class="btn btn-ghost btn-xs opacity-50 hover:opacity-100"
-							onclick={() => (activeQuadrant = activeQuadrant === 'full' ? 'top-right' : 'full')}
-							title="Zoom-Modus umschalten"
-							data-testid="zoom-toggle"
-						>
-							<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-								<circle cx="11" cy="11" r="8" /><path stroke-linecap="round" d="M21 21l-4.35-4.35M8 11h6M11 8v6" />
-							</svg>
-							<span class="text-xs">Zoom</span>
-						</button>
-					{/if}
+							class="btn btn-ghost btn-sm"
+							onclick={handleMiss}
+							disabled={game.status === 'completed'}
+							data-testid="dartboard-miss-btn"
+						>Miss (0)</button>
+						<!-- Manual zoom toggle on non-mobile -->
+						{#if !isMobile}
+							<button
+								class="btn btn-ghost btn-xs opacity-50 hover:opacity-100"
+								onclick={() => (activeQuadrant = activeQuadrant === 'full' ? 'top-right' : 'full')}
+								title="Zoom-Modus umschalten"
+								data-testid="zoom-toggle"
+							>
+								<svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+									<circle cx="11" cy="11" r="8" /><path stroke-linecap="round" d="M21 21l-4.35-4.35M8 11h6M11 8v6" />
+								</svg>
+								<span class="text-xs">Zoom</span>
+							</button>
+						{/if}
+					</div>
 				{/if}
 
 				<!-- Keypad (shown in keypad or both mode) -->


### PR DESCRIPTION
## Summary
- Animation overlays now use `pointer-events: none` — they never block dartboard/keypad clicks during gameplay
- Added "Miss (0)" button below the dartboard when in dartboard or both mode
- Added try-catch error handling around throw registration for resilience

## Root Cause
All animation effects (Bullseye, T20, 180, Checkout) used `fixed inset-0 z-50` overlays that captured all mouse/touch events, preventing any interaction with the dartboard until the animation auto-dismissed or was clicked away.

## Test plan
- [ ] Start a game, throw T20 — animation plays but dartboard remains clickable
- [ ] Throw Bullseye — same behavior
- [ ] Use "Miss (0)" button below dartboard to record a miss
- [ ] Verify game flow works: 3 darts → turn switches → continue playing
- [ ] All 147 unit tests pass