### PR TITLE
fix: resolve infinite reactive loop in ScoreBoard timer (#38)

### DIFF
--- a/src/lib/components/scoring/ScoreBoard.svelte
+++ b/src/lib/components/scoring/ScoreBoard.svelte
@@ -18,7 +18,8 @@
 	let timerEnabled = $state(settingsStore.settings.timerEnabled);
 	let elapsedSeconds = $state(0);
 	let timerStarted = $state(false);
-	let intervalId = $state<ReturnType<typeof setInterval> | null>(null);
+	// NOT $state — must not create reactive dependencies in effects
+	let intervalId: ReturnType<typeof setInterval> | null = null;
 
 	function formatTime(secs: number): string {
 		const m = Math.floor(secs / 60).toString().padStart(2, '0');


### PR DESCRIPTION
## Summary
- Fixed browser freeze caused by infinite `$effect` loop in ScoreBoard timer
- Changed `intervalId` from `$state` to plain variable — it's a timer handle, not UI state

## Root Cause
`intervalId` as `$state` created unintended reactive dependencies: timer start effect → sets `intervalId` → leg-reset effect re-runs → resets `timerStarted` → timer start re-runs → infinite loop.

## Test plan
- [ ] Start game, throw darts — no browser freeze
- [ ] Timer counts up during leg
- [ ] Timer resets on new leg