### PR TITLE
feat: in-app feedback page (#41)

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -1,8 +1,17 @@
 # Copy this to .env.deploy and fill in your values
 # .env.deploy is gitignored — never commit it
 
+# --- Deployment config ---
 # SSH target: user@host or user@ip
 DEPLOY_HOST=root@your-server-ip
 
 # Remote directory (optional, defaults to /opt/dartzone)
 # DEPLOY_DIR=/opt/dartzone
+
+# --- Runtime env vars (written to .env on server by deploy.sh) ---
+# Database path (optional, defaults to data/dartzone.db)
+# DARTZONE_DB_PATH=data/dartzone.db
+
+# GitHub fine-grained PAT for in-app feedback (Issues read/write only)
+# Create at: GitHub → Settings → Developer settings → Fine-grained tokens
+# GITHUB_TOKEN=github_pat_...

--- a/deploy.sh
+++ b/deploy.sh
@@ -64,6 +64,18 @@ else
   ssh "$REMOTE" "cd $REMOTE_DIR && npm install && npm run build"
 fi
 
+# Write runtime environment variables to server
+echo "🔐 Writing runtime environment to server..."
+{
+  echo "DARTZONE_DB_PATH=${DARTZONE_DB_PATH:-data/dartzone.db}"
+  [ -n "$GITHUB_TOKEN" ] && echo "GITHUB_TOKEN=$GITHUB_TOKEN"
+} | ssh "$REMOTE" "cat > $REMOTE_DIR/.env"
+
+# Ensure systemd service loads the .env file
+echo "🔧 Ensuring systemd EnvironmentFile is configured..."
+ssh "$REMOTE" "grep -q 'EnvironmentFile' /etc/systemd/system/dartzone.service 2>/dev/null || \
+  (sed -i '/\[Service\]/a EnvironmentFile=$REMOTE_DIR/.env' /etc/systemd/system/dartzone.service && systemctl daemon-reload)"
+
 echo "🔁 Restarting DartZone service..."
 ssh "$REMOTE" "systemctl restart dartzone"
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,6 +31,7 @@
 				<li><a href="/stats">Statistiken</a></li>
 				<li><a href="/import">Excel-Import</a></li>
 				<li><a href="/export">Backup</a></li>
+				<li><a href="/feedback">Feedback</a></li>
 			</ul>
 			<a
 				href="/settings"

--- a/src/routes/feedback/+page.server.ts
+++ b/src/routes/feedback/+page.server.ts
@@ -1,0 +1,99 @@
+import type { Actions } from './$types.js';
+import { fail } from '@sveltejs/kit';
+
+const GITHUB_OWNER = 'ChrisMoa';
+const GITHUB_REPO = 'DartZone';
+
+// Simple in-memory rate limiting: track last submission time per IP
+const lastSubmission = new Map<string, number>();
+const COOLDOWN_MS = 60_000; // 1 minute between submissions
+
+export const actions: Actions = {
+	default: async ({ request, getClientAddress }) => {
+		const data = await request.formData();
+		const title = (data.get('title') as string)?.trim() ?? '';
+		const category = (data.get('category') as string)?.trim() ?? '';
+		const description = (data.get('description') as string)?.trim() ?? '';
+
+		const token = process.env.GITHUB_TOKEN;
+		if (!token) {
+			return fail(500, {
+				error: 'GitHub-Token ist nicht konfiguriert. Bitte GITHUB_TOKEN in der Server-Umgebung setzen.',
+				title,
+				category,
+				description
+			});
+		}
+
+		const clientIp = getClientAddress();
+		const now = Date.now();
+		const lastTime = lastSubmission.get(clientIp);
+		if (lastTime && now - lastTime < COOLDOWN_MS) {
+			const waitSec = Math.ceil((COOLDOWN_MS - (now - lastTime)) / 1000);
+			return fail(429, {
+				error: `Bitte warte ${waitSec} Sekunden vor dem nächsten Feedback.`,
+				title,
+				category,
+				description
+			});
+		}
+
+		if (!title || title.length < 3) {
+			return fail(400, { error: 'Titel muss mindestens 3 Zeichen lang sein.', title, category, description });
+		}
+		if (!description || description.length < 10) {
+			return fail(400, {
+				error: 'Beschreibung muss mindestens 10 Zeichen lang sein.',
+				title,
+				category,
+				description
+			});
+		}
+		const validCategories = ['Bug', 'Feature', 'Sonstiges'];
+		if (!category || !validCategories.includes(category)) {
+			return fail(400, { error: 'Ungültige Kategorie.', title, category, description });
+		}
+
+		const labelMap: Record<string, string> = {
+			Bug: 'bug',
+			Feature: 'enhancement',
+			Sonstiges: 'feedback'
+		};
+
+		const issueTitle = `[${category}] ${title}`;
+		const issueBody = `**Kategorie:** ${category}\n\n${description}\n\n---\n*Erstellt über DartZone In-App Feedback*`;
+
+		const labels = [labelMap[category]].filter(Boolean);
+
+		const response = await fetch(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/issues`, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				Accept: 'application/vnd.github+json',
+				'Content-Type': 'application/json',
+				'X-GitHub-Api-Version': '2022-11-28'
+			},
+			body: JSON.stringify({
+				title: issueTitle,
+				body: issueBody,
+				labels
+			})
+		});
+
+		if (!response.ok) {
+			const errorText = await response.text();
+			console.error('GitHub API error:', response.status, errorText);
+			return fail(502, {
+				error: 'Fehler beim Erstellen des GitHub-Issues. Bitte später erneut versuchen.',
+				title,
+				category,
+				description
+			});
+		}
+
+		const issue = await response.json();
+		lastSubmission.set(clientIp, Date.now());
+
+		return { success: true, issueUrl: issue.html_url, issueNumber: issue.number };
+	}
+};

--- a/src/routes/feedback/+page.svelte
+++ b/src/routes/feedback/+page.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import { enhance } from '$app/forms';
+
+	let { form } = $props();
+
+	let submitting = $state(false);
+</script>
+
+<div class="max-w-xl mx-auto" data-testid="feedback-page">
+	<h1 class="text-2xl font-bold mb-6">Feedback</h1>
+	<p class="text-base-content/70 mb-6">
+		Bug gefunden oder eine Idee? Dein Feedback wird direkt als GitHub-Issue erstellt.
+	</p>
+
+	{#if form?.success}
+		<div class="alert alert-success mb-6" data-testid="feedback-success">
+			<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+			</svg>
+			<div>
+				<p class="font-semibold">Feedback gesendet!</p>
+				<p>
+					Issue
+					<a href={form.issueUrl} target="_blank" rel="noopener noreferrer" class="link link-primary">
+						#{form.issueNumber}
+					</a>
+					wurde erstellt.
+				</p>
+			</div>
+		</div>
+	{/if}
+
+	{#if form?.error}
+		<div class="alert alert-error mb-6" data-testid="feedback-error">
+			<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" />
+			</svg>
+			<span>{form.error}</span>
+		</div>
+	{/if}
+
+	<form
+		method="POST"
+		use:enhance={() => {
+			submitting = true;
+			return async ({ update }) => {
+				await update();
+				submitting = false;
+			};
+		}}
+		class="flex flex-col gap-4"
+		data-testid="feedback-form"
+	>
+		<div class="form-control">
+			<label class="label" for="category">
+				<span class="label-text">Kategorie</span>
+			</label>
+			<select
+				id="category"
+				name="category"
+				class="select select-bordered w-full"
+				required
+				value={form?.category ?? 'Bug'}
+				data-testid="feedback-category"
+			>
+				<option value="Bug">Bug</option>
+				<option value="Feature">Feature-Wunsch</option>
+				<option value="Sonstiges">Sonstiges</option>
+			</select>
+		</div>
+
+		<div class="form-control">
+			<label class="label" for="title">
+				<span class="label-text">Titel</span>
+			</label>
+			<input
+				id="title"
+				name="title"
+				type="text"
+				class="input input-bordered w-full"
+				placeholder="Kurze Zusammenfassung..."
+				required
+				minlength="3"
+				value={form?.title ?? ''}
+				data-testid="feedback-title"
+			/>
+		</div>
+
+		<div class="form-control">
+			<label class="label" for="description">
+				<span class="label-text">Beschreibung</span>
+			</label>
+			<textarea
+				id="description"
+				name="description"
+				class="textarea textarea-bordered w-full h-32"
+				placeholder="Was ist passiert? Was hast du erwartet?"
+				required
+				minlength="10"
+				data-testid="feedback-description"
+			>{form?.description ?? ''}</textarea>
+		</div>
+
+		<button
+			type="submit"
+			class="btn btn-primary"
+			disabled={submitting}
+			data-testid="feedback-submit"
+		>
+			{#if submitting}
+				<span class="loading loading-spinner loading-sm"></span>
+				Wird gesendet...
+			{:else}
+				Feedback senden
+			{/if}
+		</button>
+	</form>
+</div>


### PR DESCRIPTION
## Summary
- Add `/feedback` route with form (title, category, description) that creates GitHub issues via server-side API call
- Rate limiting (1 min cooldown per IP), input validation, German UI labels
- `GITHUB_TOKEN` env var configured in `.env.deploy`, written to server by `deploy.sh`
- `deploy.sh` now writes runtime `.env` to server and ensures systemd `EnvironmentFile` is set
- Nav link added to layout

Closes #41