### PR TITLE
fix: migrate inputMode to keypad for existing users (#49)

### DIFF
--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -43,7 +43,19 @@ function loadSettings(): AppSettings {
 	if (stored) {
 		try {
 			const parsed = JSON.parse(stored);
-			return { ...DEFAULTS, ...parsed };
+			const result = { ...DEFAULTS, ...parsed };
+
+			// Migration: switch dartboard → keypad default (introduced after #44)
+			if (!parsed._migratedKeypadDefault && result.inputMode === 'dartboard') {
+				result.inputMode = 'keypad';
+				result._migratedKeypadDefault = true;
+				localStorage.setItem(STORAGE_KEY, JSON.stringify(result));
+			} else if (!parsed._migratedKeypadDefault) {
+				result._migratedKeypadDefault = true;
+				localStorage.setItem(STORAGE_KEY, JSON.stringify(result));
+			}
+
+			return result;
 		} catch { /* ignore */ }
 	}
 


### PR DESCRIPTION
## Summary
- Existing users had `inputMode: 'dartboard'` persisted in localStorage, so the default change from #44 had no effect
- Adds a one-time migration flag (`_migratedKeypadDefault`) that switches `dartboard` → `keypad` on first load
- Users who manually chose `keypad` or `both` are unaffected
- Users can still switch back to dartboard via the input mode toggle

Closes #49

## Test plan
- [ ] Clear localStorage or use existing browser with old settings
- [ ] Load the play page — keypad should now be the active input mode
- [ ] Toggle to dartboard, reload — dartboard stays (migration only runs once)