### PR TITLE
feat: Turnierstatus-Lifecycle (planned/running/finished/aborted)

### DIFF
--- a/src/lib/components/league/SeasonSelector.svelte
+++ b/src/lib/components/league/SeasonSelector.svelte
@@ -21,7 +21,7 @@
 	{#each tournaments as tournament (tournament.id)}
 		<option value={tournament.id}>
 			{tournament.name}
-			{#if tournament.is_active}(aktiv){/if}
+			{#if tournament.status === 'running'}(laufend){/if}
 		</option>
 	{/each}
 </select>

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -37,13 +37,22 @@ function runMigrations(database: Database.Database): void {
 		['organizer_logo', 'ALTER TABLE tournaments ADD COLUMN organizer_logo BLOB'],
 		['organizer_logo_mime', 'ALTER TABLE tournaments ADD COLUMN organizer_logo_mime TEXT'],
 		['organizer_contact', 'ALTER TABLE tournaments ADD COLUMN organizer_contact TEXT'],
-		['organizer_note', 'ALTER TABLE tournaments ADD COLUMN organizer_note TEXT']
+		['organizer_note', 'ALTER TABLE tournaments ADD COLUMN organizer_note TEXT'],
+		['status', 'ALTER TABLE tournaments ADD COLUMN status TEXT NOT NULL DEFAULT \'planned\'']
 	];
 
 	for (const [col, sql] of migrations) {
 		if (!colNames.has(col)) {
 			database.exec(sql);
 		}
+	}
+
+	// Migrate is_active → status
+	if (colNames.has('is_active') && colNames.has('status')) {
+		database.exec(`UPDATE tournaments SET status = 'running' WHERE is_active = 1 AND status = 'planned'`);
+	} else if (colNames.has('is_active') && !colNames.has('status')) {
+		// status column was just added above — migrate values
+		database.exec(`UPDATE tournaments SET status = 'running' WHERE is_active = 1`);
 	}
 }
 

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -34,8 +34,8 @@ function seedDatabase(): void {
 		 VALUES (@id, @club_id, @first_name, @last_name, @nickname, @created_at)`
 	);
 	const insertTournament = db.prepare(
-		`INSERT INTO tournaments (id, name, game_mode, format, legs_per_set, sets_per_match, start_date, end_date, is_active)
-		 VALUES (@id, @name, @game_mode, @format, @legs_per_set, @sets_per_match, @start_date, @end_date, @is_active)`
+		`INSERT INTO tournaments (id, name, game_mode, format, legs_per_set, sets_per_match, start_date, end_date, status)
+		 VALUES (@id, @name, @game_mode, @format, @legs_per_set, @sets_per_match, @start_date, @end_date, @status)`
 	);
 	const insertTournamentClub = db.prepare(
 		`INSERT INTO tournament_clubs (tournament_id, club_id) VALUES (?, ?)`
@@ -53,7 +53,7 @@ function seedDatabase(): void {
 			insertPlayer.run(player);
 		}
 		for (const tournament of seedTournaments) {
-			insertTournament.run({ ...tournament, is_active: tournament.is_active ? 1 : 0 });
+			insertTournament.run(tournament);
 		}
 		for (const [tournamentId, clubIds] of Object.entries(seedTournamentClubs)) {
 			for (const clubId of clubIds) {

--- a/src/lib/server/repository.ts
+++ b/src/lib/server/repository.ts
@@ -35,6 +35,7 @@ export interface TournamentRepository {
 	removeClub(tournamentId: string, clubId: string): Promise<void>;
 	getLogoData(id: string): Promise<{ data: Buffer; mime: string } | null>;
 	setLogoData(id: string, data: Buffer, mime: string): Promise<boolean>;
+	updateStatus(id: string, status: Tournament['status']): Promise<Tournament | null>;
 }
 
 export interface MatchRepository {

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -32,7 +32,7 @@ CREATE TABLE IF NOT EXISTS tournaments (
 	sets_per_match INTEGER NOT NULL DEFAULT 5,
 	start_date TEXT,
 	end_date TEXT,
-	is_active INTEGER NOT NULL DEFAULT 0,
+	status TEXT NOT NULL DEFAULT 'planned',
 	organizer_name TEXT,
 	organizer_logo BLOB,
 	organizer_logo_mime TEXT,

--- a/src/lib/server/seed.ts
+++ b/src/lib/server/seed.ts
@@ -70,7 +70,7 @@ export const seedTournaments: Tournament[] = [
 		sets_per_match: 5,
 		start_date: '2026-03-15',
 		end_date: null,
-		is_active: true,
+		status: 'running',
 		organizer_name: null,
 		has_organizer_logo: false,
 		organizer_contact: null,

--- a/src/lib/server/sqlite-repository.ts
+++ b/src/lib/server/sqlite-repository.ts
@@ -217,7 +217,7 @@ export class SqlitePlayerRepository implements PlayerRepository {
 // --- Tournament Repository ---
 
 const TOURNAMENT_COLUMNS = `id, name, game_mode, format, legs_per_set, sets_per_match,
-	start_date, end_date, is_active, organizer_name, organizer_contact, organizer_note,
+	start_date, end_date, status, organizer_name, organizer_contact, organizer_note,
 	(organizer_logo IS NOT NULL) as has_organizer_logo`;
 
 interface TournamentRow {
@@ -229,7 +229,7 @@ interface TournamentRow {
 	sets_per_match: number;
 	start_date: string | null;
 	end_date: string | null;
-	is_active: number;
+	status: string;
 	organizer_name: string | null;
 	organizer_contact: string | null;
 	organizer_note: string | null;
@@ -249,7 +249,7 @@ export class SqliteTournamentRepository implements TournamentRepository {
 			sets_per_match: row.sets_per_match,
 			start_date: row.start_date,
 			end_date: row.end_date,
-			is_active: row.is_active === 1,
+			status: row.status as Tournament['status'],
 			organizer_name: row.organizer_name,
 			has_organizer_logo: row.has_organizer_logo === 1,
 			organizer_contact: row.organizer_contact,
@@ -269,7 +269,7 @@ export class SqliteTournamentRepository implements TournamentRepository {
 	}
 
 	async getActive(): Promise<Tournament | null> {
-		const row = this.db.prepare(`SELECT ${TOURNAMENT_COLUMNS} FROM tournaments WHERE is_active = 1`).get() as TournamentRow | undefined;
+		const row = this.db.prepare(`SELECT ${TOURNAMENT_COLUMNS} FROM tournaments WHERE status = 'running'`).get() as TournamentRow | undefined;
 		if (!row) return null;
 		return this.rowToTournament(row);
 	}
@@ -278,8 +278,8 @@ export class SqliteTournamentRepository implements TournamentRepository {
 		const id = generateId();
 		this.db
 			.prepare(
-				`INSERT INTO tournaments (id, name, game_mode, format, legs_per_set, sets_per_match, start_date, end_date, is_active, organizer_name, organizer_contact, organizer_note)
-				 VALUES (@id, @name, @game_mode, @format, @legs_per_set, @sets_per_match, @start_date, @end_date, @is_active, @organizer_name, @organizer_contact, @organizer_note)`
+				`INSERT INTO tournaments (id, name, game_mode, format, legs_per_set, sets_per_match, start_date, end_date, status, organizer_name, organizer_contact, organizer_note)
+				 VALUES (@id, @name, @game_mode, @format, @legs_per_set, @sets_per_match, @start_date, @end_date, @status, @organizer_name, @organizer_contact, @organizer_note)`
 			)
 			.run({
 				id,
@@ -290,7 +290,7 @@ export class SqliteTournamentRepository implements TournamentRepository {
 				sets_per_match: data.sets_per_match,
 				start_date: data.start_date,
 				end_date: data.end_date,
-				is_active: data.is_active ? 1 : 0,
+				status: data.status,
 				organizer_name: data.organizer_name ?? null,
 				organizer_contact: data.organizer_contact ?? null,
 				organizer_note: data.organizer_note ?? null
@@ -307,17 +307,23 @@ export class SqliteTournamentRepository implements TournamentRepository {
 				`UPDATE tournaments SET name = @name, game_mode = @game_mode, format = @format,
 				 legs_per_set = @legs_per_set, sets_per_match = @sets_per_match,
 				 start_date = @start_date, end_date = @end_date,
-				 is_active = @is_active, organizer_name = @organizer_name,
+				 status = @status, organizer_name = @organizer_name,
 				 organizer_contact = @organizer_contact, organizer_note = @organizer_note
 				 WHERE id = @id`
 			)
 			.run({
 				...updated,
-				is_active: updated.is_active ? 1 : 0,
 				organizer_name: updated.organizer_name ?? null,
 				organizer_contact: updated.organizer_contact ?? null,
 				organizer_note: updated.organizer_note ?? null
 			});
+		return this.getById(id);
+	}
+
+	async updateStatus(id: string, status: Tournament['status']): Promise<Tournament | null> {
+		const existing = await this.getById(id);
+		if (!existing) return null;
+		this.db.prepare('UPDATE tournaments SET status = ? WHERE id = ?').run(status, id);
 		return this.getById(id);
 	}
 

--- a/src/lib/types/league.ts
+++ b/src/lib/types/league.ts
@@ -1,5 +1,7 @@
 import type { Club } from './club.js';
 
+export type TournamentStatus = 'planned' | 'running' | 'finished' | 'aborted';
+
 export interface Tournament {
 	id: string;
 	name: string;
@@ -9,7 +11,7 @@ export interface Tournament {
 	sets_per_match: number;
 	start_date: string | null;
 	end_date: string | null;
-	is_active: boolean;
+	status: TournamentStatus;
 	organizer_name: string | null;
 	has_organizer_logo: boolean;
 	organizer_contact: string | null;

--- a/src/lib/utils/validation.ts
+++ b/src/lib/utils/validation.ts
@@ -55,7 +55,7 @@ export const tournamentSchema = z.object({
 	sets_per_match: z.number().int().min(1).max(13),
 	start_date: z.string().nullable().optional().default(null),
 	end_date: z.string().nullable().optional().default(null),
-	is_active: z.boolean().default(false)
+	status: z.enum(['planned', 'running', 'finished', 'aborted']).default('planned')
 });
 
 export type ClubFormData = z.infer<typeof clubSchema>;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -86,7 +86,7 @@
 				</div>
 			{/if}
 			<div class="text-center">
-				<p class="text-base-content/60 mb-4">Kein aktives Turnier vorhanden.</p>
+				<p class="text-base-content/60 mb-4">Kein laufendes Turnier vorhanden.</p>
 				<a href="/tournaments/new" class="btn btn-primary">Turnier erstellen</a>
 			</div>
 		</div>

--- a/src/routes/api/import/+server.ts
+++ b/src/routes/api/import/+server.ts
@@ -110,7 +110,7 @@ async function importJson(file: File) {
 
 		// Import tournaments
 		const insertTournament = db.prepare(
-			`INSERT OR IGNORE INTO tournaments (id, name, game_mode, format, legs_per_set, sets_per_match, start_date, end_date, is_active)
+			`INSERT OR IGNORE INTO tournaments (id, name, game_mode, format, legs_per_set, sets_per_match, start_date, end_date, status)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 		);
 		const insertTournamentClub = db.prepare(
@@ -131,7 +131,7 @@ async function importJson(file: File) {
 				tournament.sets_per_match ?? 5,
 				tournament.start_date ?? null,
 				tournament.end_date ?? null,
-				tournament.is_active ? 1 : 0
+				tournament.status ?? (tournament.is_active ? 'running' : 'planned')
 			);
 
 			// Assign clubs

--- a/src/routes/tournaments/+page.svelte
+++ b/src/routes/tournaments/+page.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
+	import type { TournamentStatus } from '$lib/types/league.js';
+
 	let { data } = $props();
+
+	const STATUS_BADGE: Record<TournamentStatus, { label: string; class: string }> = {
+		planned: { label: 'Geplant', class: 'badge-info' },
+		running: { label: 'Laufend', class: 'badge-success' },
+		finished: { label: 'Beendet', class: 'badge-neutral' },
+		aborted: { label: 'Abgebrochen', class: 'badge-error' }
+	};
 </script>
 
 <div class="flex flex-col gap-6">
@@ -15,7 +24,12 @@
 	{:else}
 		<div class="grid gap-4" data-testid="tournament-list">
 			{#each data.tournaments as tournament (tournament.id)}
-				<a href="/tournaments/{tournament.id}" class="card card-border bg-base-100 shadow-sm hover:shadow-md transition-shadow" data-testid="tournament-card">
+				<a
+					href="/tournaments/{tournament.id}"
+					class="card card-border bg-base-100 shadow-sm hover:shadow-md transition-shadow"
+					class:opacity-60={tournament.status === 'finished' || tournament.status === 'aborted'}
+					data-testid="tournament-card"
+				>
 					<div class="card-body flex-row items-center justify-between">
 						<div>
 							<h2 class="card-title text-base">{tournament.name}</h2>
@@ -25,9 +39,9 @@
 								{tournament.legs_per_set} Legs/Set &middot; {tournament.sets_per_match} Sets/Match
 							</p>
 						</div>
-						{#if tournament.is_active}
-							<span class="badge badge-success">Aktiv</span>
-						{/if}
+						<span class="badge {STATUS_BADGE[tournament.status].class}" data-testid="tournament-status-badge">
+							{STATUS_BADGE[tournament.status].label}
+						</span>
 					</div>
 				</a>
 			{/each}

--- a/src/routes/tournaments/[id]/+page.server.ts
+++ b/src/routes/tournaments/[id]/+page.server.ts
@@ -75,6 +75,18 @@ export const actions: Actions = {
 		return { success: true };
 	},
 
+	updateStatus: async ({ request, params }) => {
+		const formData = await request.formData();
+		const status = formData.get('status') as string;
+		const validStatuses = ['planned', 'running', 'finished', 'aborted'];
+		if (!validStatuses.includes(status)) return fail(400, { error: 'Ungueltiger Status' });
+
+		const updated = await tournamentRepo.updateStatus(params.id, status as 'planned' | 'running' | 'finished' | 'aborted');
+		if (!updated) return fail(404, { error: 'Turnier nicht gefunden' });
+
+		return { success: true };
+	},
+
 	generatePairings: async ({ params }) => {
 		const tournament = await tournamentRepo.getById(params.id);
 		if (!tournament) return fail(404, { error: 'Turnier nicht gefunden' });

--- a/src/routes/tournaments/[id]/+page.svelte
+++ b/src/routes/tournaments/[id]/+page.svelte
@@ -3,26 +3,51 @@
 	import MatchCard from '$lib/components/league/MatchCard.svelte';
 	import KnockoutBracket from '$lib/components/league/KnockoutBracket.svelte';
 	import ClubCrest from '$lib/components/clubs/ClubCrest.svelte';
+	import type { TournamentStatus } from '$lib/types/league.js';
 
 	let { data } = $props();
 
 	const formatLabel = $derived(
 		data.tournament.format === 'round_robin' ? 'Jeder gegen Jeden' : 'K.O.'
 	);
+
+	const STATUS_BADGE: Record<TournamentStatus, { label: string; class: string }> = {
+		planned: { label: 'Geplant', class: 'badge-info' },
+		running: { label: 'Laufend', class: 'badge-success' },
+		finished: { label: 'Beendet', class: 'badge-neutral' },
+		aborted: { label: 'Abgebrochen', class: 'badge-error' }
+	};
+
+	const STATUS_LABELS: Record<TournamentStatus, string> = {
+		planned: 'Geplant',
+		running: 'Laufend',
+		finished: 'Beendet',
+		aborted: 'Abgebrochen'
+	};
 </script>
 
 <div class="flex flex-col gap-6">
 	<div class="flex items-center gap-4">
 		<a href="/tournaments" class="btn btn-ghost btn-sm">Zurueck</a>
 		<h1 class="text-2xl font-bold">{data.tournament.name}</h1>
-		{#if data.tournament.is_active}
-			<span class="badge badge-success">Aktiv</span>
-		{/if}
+		<span class="badge {STATUS_BADGE[data.tournament.status].class}" data-testid="tournament-status-badge">
+			{STATUS_BADGE[data.tournament.status].label}
+		</span>
 	</div>
 
-	<div class="text-sm text-base-content/60">
-		{data.tournament.game_mode} &middot; {formatLabel} &middot;
-		{data.tournament.legs_per_set} Legs/Set &middot; {data.tournament.sets_per_match} Sets/Match
+	<div class="flex items-center gap-4 text-sm text-base-content/60">
+		<span>
+			{data.tournament.game_mode} &middot; {formatLabel} &middot;
+			{data.tournament.legs_per_set} Legs/Set &middot; {data.tournament.sets_per_match} Sets/Match
+		</span>
+		<form method="POST" action="?/updateStatus" class="flex items-center gap-2" data-testid="status-form">
+			<select name="status" class="select select-bordered select-xs" value={data.tournament.status} data-testid="status-select">
+				{#each Object.entries(STATUS_LABELS) as [value, label]}
+					<option {value} selected={value === data.tournament.status}>{label}</option>
+				{/each}
+			</select>
+			<button type="submit" class="btn btn-xs btn-outline" data-testid="status-submit">Aendern</button>
+		</form>
 	</div>
 
 	<!-- Organizer card -->

--- a/src/routes/tournaments/new/+page.server.ts
+++ b/src/routes/tournaments/new/+page.server.ts
@@ -14,7 +14,7 @@ export const actions: Actions = {
 			sets_per_match: Number(formData.get('sets_per_match')),
 			start_date: (formData.get('start_date') as string) || null,
 			end_date: (formData.get('end_date') as string) || null,
-			is_active: formData.get('is_active') === 'on',
+			status: (formData.get('status') as string) || 'planned',
 			organizer_name: (formData.get('organizer_name') as string) || null,
 			organizer_contact: (formData.get('organizer_contact') as string) || null,
 			organizer_note: (formData.get('organizer_note') as string) || null

--- a/src/routes/tournaments/new/+page.svelte
+++ b/src/routes/tournaments/new/+page.svelte
@@ -58,10 +58,11 @@
 		</div>
 
 		<div class="form-control">
-			<label class="label cursor-pointer justify-start gap-2">
-				<input type="checkbox" name="is_active" class="checkbox" />
-				<span>Aktives Turnier</span>
-			</label>
+			<label class="label" for="status">Status</label>
+			<select id="status" name="status" class="select select-bordered w-full" data-testid="tournament-form-status">
+				<option value="planned">Geplant</option>
+				<option value="running">Laufend</option>
+			</select>
 		</div>
 
 		<!-- Organizer section (collapsible) -->

--- a/tests/unit/validation.test.ts
+++ b/tests/unit/validation.test.ts
@@ -154,7 +154,7 @@ describe('tournamentSchema', () => {
 			legs_per_set: 3,
 			sets_per_match: 5,
 			start_date: '2026-03-15',
-			is_active: true
+			status: 'running'
 		});
 		expect(result.success).toBe(true);
 	});


### PR DESCRIPTION
## Summary
- Replaces `is_active: boolean` with `status: TournamentStatus` (`planned`, `running`, `finished`, `aborted`)
- Adds DB migration: `is_active = 1` → `status = 'running'`, `is_active = 0` → `status = 'planned'`
- Color-coded status badges on tournament list and detail pages
- Status change dropdown on tournament detail page
- Finished/aborted tournaments visually dimmed in list (opacity-60)
- Dashboard shows only `running` tournaments as active

Closes #51

## Test plan
- [x] All 174 existing tests pass (5 pre-existing ScoreBoard failures unrelated)
- [x] svelte-check passes (0 new errors)
- [ ] Manual: Create tournament → verify default status "Geplant"
- [ ] Manual: Change status via dropdown on detail page
- [ ] Manual: Verify finished/aborted tournaments are dimmed in list
- [ ] Manual: Verify dashboard only shows running tournaments
- [ ] Manual: Existing DB migrates correctly (is_active → status)