### PR TITLE
feat: Versionierung mit SemVer, Changelog und Release-Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:unit
+
+      # For workflow_dispatch: bump version, commit, tag, push
+      - name: Bump version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version ${{ inputs.bump }} -m "release: v%s"
+          git push origin main --follow-tags
+
+      - name: Get version
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog for version
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract the section for this version from CHANGELOG.md
+          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v${VERSION}"
+          fi
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Build
+        run: npm run build
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          body: ${{ steps.changelog.outputs.notes }}
+          generate_release_notes: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2025-03-18
+
+### Added
+- Interactive SVG dartboard with click detection (Single, Double, Triple, Bull, Bullseye)
+- Game scoring engine with turn management, undo, bust detection
+- Checkout route calculator with suggested finishes
+- Club management (CRUD, crest upload as BLOB in SQLite)
+- Player management with club assignment
+- Tournament management with status lifecycle (planned, running, finished, aborted)
+- Tournament formats: Round Robin and Knockout with auto-generated match pairings
+- League table with live standings
+- Match scheduling and result tracking
+- GSAP-powered animations for special hits (Bullseye, T20, 180, Checkout)
+- Custom animation uploads (GIF, WebP, MP4, WebM, Lottie)
+- Player and club statistics with averages and checkout percentages
+- Dartboard heatmap overlay
+- Excel import for clubs and players
+- Database backup and restore (SQLite export/import)
+- In-app feedback page (creates GitHub issues)
+- Settings page with theme customization, color presets, animation toggles
+- Dark/light mode toggle
+- Responsive design with DaisyUI components
+- SQLite persistence with repository pattern
+- Versioning system with build date display

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "dartzone",
 	"private": true,
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,6 +1,7 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
 declare const __APP_VERSION__: string;
+declare const __APP_BUILD_DATE__: string;
 
 declare global {
 	namespace App {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,7 +22,7 @@
 <div class="min-h-screen bg-base-200">
 	<nav class="navbar bg-gradient-to-r from-base-100 to-base-200 shadow-sm sticky top-0 z-40 border-b border-base-300/50">
 		<div class="flex-1">
-			<a href="/" class="btn btn-ghost text-xl font-bold text-primary" title="DartZone v{__APP_VERSION__}">DartZone</a>
+			<a href="/" class="btn btn-ghost text-xl font-bold text-primary" title="DartZone v{__APP_VERSION__} (Build: {__APP_BUILD_DATE__})">DartZone</a>
 		</div>
 		<div class="flex-none flex items-center gap-1">
 			<ul class="menu menu-horizontal gap-1">

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -605,6 +605,6 @@
 
 	<!-- Version -->
 	<div class="text-center text-xs text-base-content/40 py-4" data-testid="app-version">
-		DartZone v{__APP_VERSION__}
+		DartZone v{__APP_VERSION__} &middot; Build: {__APP_BUILD_DATE__}
 	</div>
 </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,8 @@ const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
 
 export default defineConfig({
 	define: {
-		__APP_VERSION__: JSON.stringify(pkg.version)
+		__APP_VERSION__: JSON.stringify(pkg.version),
+		__APP_BUILD_DATE__: JSON.stringify(new Date().toISOString().split('T')[0])
 	},
 	plugins: [tailwindcss(), sveltekit()],
 	test: {


### PR DESCRIPTION
## Summary
- Bump version from `0.0.1` to `1.0.0` (SemVer)
- Add `__APP_BUILD_DATE__` Vite define for build date injection
- Create `CHANGELOG.md` documenting all existing features (Keep a Changelog format)
- Add GitHub Actions release workflow (manual dispatch with patch/minor/major choice, or tag push trigger)
- Show version + build date in navbar tooltip and settings footer

## Betroffene Dateien
- `package.json` — version 1.0.0
- `vite.config.ts` — `__APP_BUILD_DATE__` define
- `src/app.d.ts` — type declaration for `__APP_BUILD_DATE__`
- `src/routes/+layout.svelte` — navbar tooltip with build date
- `src/routes/settings/+page.svelte` — footer with build date
- `CHANGELOG.md` — new
- `.github/workflows/release.yml` — new

## Test plan
- [x] All 147 unit tests pass
- [ ] Verify navbar tooltip shows version + build date
- [ ] Verify settings page footer shows version + build date
- [ ] Verify release workflow syntax is valid

Closes #53